### PR TITLE
Cosmos Async Queryable Provider

### DIFF
--- a/EventSourcing.Core/IEventStore.cs
+++ b/EventSourcing.Core/IEventStore.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -10,7 +9,7 @@ namespace EventSourcing.Core
 
   public interface IEventStore<TBaseEvent> where TBaseEvent : Event
   {
-    IAsyncEnumerable<T> Query<T>(Func<IQueryable<TBaseEvent>, IQueryable<T>> func);
+    IQueryable<TBaseEvent> Events { get; }
     Task AddAsync(IList<TBaseEvent> events, CancellationToken cancellationToken = default);
   }
 }

--- a/EventSourcing.Core/QueryableExtensions.cs
+++ b/EventSourcing.Core/QueryableExtensions.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventSourcing.Core
+{
+  public static class QueryableExtensions
+  {
+    public static IAsyncEnumerable<T> ToAsyncEnumerable<T>(this IQueryable<T> source) => (IAsyncEnumerable<T>) source;
+
+    public static async Task<List<T>> ToListAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken = default)
+    {
+      var list = new List<T>();
+      await foreach (var element in source.ToAsyncEnumerable().WithCancellation(cancellationToken))
+        list.Add(element);
+      return list;
+    }
+  }
+}

--- a/EventSourcing.Cosmos.Tests/EventStoreTests.cs
+++ b/EventSourcing.Cosmos.Tests/EventStoreTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using EventSourcing.Core;
 using EventSourcing.Core.Exceptions;
@@ -95,6 +96,27 @@ namespace EventSourcing.Cosmos.Tests
 
       await Assert.ThrowsAnyAsync<EventStoreException>(
         async () => await Store.AddAsync(new Event[] { event1, event2 }));
+    }
+
+    [Fact]
+    public async Task Can_Get_Events_By_AggregateId()
+    {
+      var aggregate = new EmptyAggregate();
+      var events = new List<Event>
+      {
+        aggregate.Add(Event.Create<EmptyEvent>(aggregate)),
+        aggregate.Add(Event.Create<EmptyEvent>(aggregate)),
+        aggregate.Add(Event.Create<EmptyEvent>(aggregate)),
+        aggregate.Add(Event.Create<EmptyEvent>(aggregate)),
+      };
+
+      await Store.AddAsync(events);
+
+      var result = await Store.Events
+        .Where(x => x.AggregateId == aggregate.Id)
+        .ToListAsync();
+      
+      Assert.Equal(events.Count, result.Count);
     }
   }
 }

--- a/EventSourcing.Cosmos/CosmosAsyncQueryableProvider.cs
+++ b/EventSourcing.Cosmos/CosmosAsyncQueryableProvider.cs
@@ -8,7 +8,7 @@ using Microsoft.Azure.Cosmos.Linq;
 
 namespace EventSourcing.Cosmos
 {
-  internal class CosmosAsyncQueryable<TResult> : IQueryable<TResult>, IAsyncEnumerable<TResult>
+  internal class CosmosAsyncQueryable<TResult> : IOrderedQueryable<TResult>, IAsyncEnumerable<TResult>
   {
     private readonly IQueryable<TResult> _queryable;
 

--- a/EventSourcing.Cosmos/CosmosAsyncQueryableProvider.cs
+++ b/EventSourcing.Cosmos/CosmosAsyncQueryableProvider.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using Microsoft.Azure.Cosmos.Linq;
+
+namespace EventSourcing.Cosmos
+{
+  internal class CosmosAsyncQueryable<TResult> : IQueryable<TResult>, IAsyncEnumerable<TResult>
+  {
+    private readonly IQueryable<TResult> _queryable;
+
+    public CosmosAsyncQueryable(IQueryable<TResult> queryable)
+    {
+      _queryable = queryable;
+      Provider = new CosmosAsyncQueryableProvider(queryable.Provider);
+    }
+
+    public Type ElementType => typeof(TResult);
+
+    public Expression Expression => _queryable.Expression;
+
+    public IQueryProvider Provider { get; }
+
+    public IEnumerator<TResult> GetEnumerator() => _queryable.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _queryable.GetEnumerator();
+
+    public async IAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+      var iterator = _queryable.ToFeedIterator();
+      while (iterator.HasMoreResults)
+        foreach (var item in await iterator.ReadNextAsync(cancellationToken))
+          yield return item;
+    }
+  }
+
+  internal class CosmosAsyncQueryableProvider : IQueryProvider
+  {
+    private readonly IQueryProvider _provider;
+    public CosmosAsyncQueryableProvider(IQueryProvider provider) =>
+      _provider = provider;
+
+    public IQueryable<TElement> CreateQuery<TElement>(Expression expression) =>
+      new CosmosAsyncQueryable<TElement>(_provider.CreateQuery<TElement>(expression));
+
+    public IQueryable CreateQuery(Expression expression) =>
+      CreateQuery<object>(expression);
+
+    public object Execute(Expression expression) =>
+      _provider.Execute(expression);
+
+    public TResult Execute<TResult>(Expression expression) =>
+      _provider.Execute<TResult>(expression);
+  }
+}

--- a/EventSourcing.Cosmos/CosmosEventStore.cs
+++ b/EventSourcing.Cosmos/CosmosEventStore.cs
@@ -57,9 +57,13 @@ namespace EventSourcing.Cosmos
         });
     }
 
+    public IQueryable<TBaseEvent> Events =>
+      new CosmosAsyncQueryable<TBaseEvent>(_container.GetItemLinqQueryable<TBaseEvent>());
+
     public async IAsyncEnumerable<T> Query<T>(Func<IQueryable<TBaseEvent>, IQueryable<T>> func)
     {
-      var iterator = func(_container.GetItemLinqQueryable<TBaseEvent>()).ToFeedIterator();
+      var queryable = func(_container.GetItemLinqQueryable<TBaseEvent>());
+      var iterator = queryable.ToFeedIterator();
       
       while (iterator.HasMoreResults)
         foreach (var item in await iterator.ReadNextAsync())


### PR DESCRIPTION
- Improve ```IEventStore``` API by exposing ```IQueryable<TBaseEvent>``` directly
- Add ```CosmosAsyncQueryableProvider``` to allow Async Extension Methods (e.g. from System.Linq.Async)
- Add few IQueryable extension methods to not be dependent on System.Linq.Async
- Add test that illustrates use (more test needed in future PRs)