### PR TITLE
Aggregate Store

### DIFF
--- a/EventSourcing.Core.Tests/AggregateTests.cs
+++ b/EventSourcing.Core.Tests/AggregateTests.cs
@@ -83,5 +83,12 @@ namespace EventSourcing.Core.Tests
             
             Assert.Empty(aggregate.UncommittedEvents);
         }
+
+        [Fact]
+        public void Can_Calculate_Aggregate_Hash()
+        {
+            var hash = Aggregate.Hash<SimpleAggregate>();
+            Assert.Equal("C927ADDF0A910D15CC13DDD06FE7C0D63590C984", hash);
+        }
     }
 }


### PR DESCRIPTION
Beginnings of Aggregate Store

Idea:
- Store latest Aggregate when Persisting its Events
  - Allows for nice complex queries on (multiple) Aggregates, good for FE filtered/paginated requests!
  - Allows for quick rehydrate (?!)
  - Aggregates can be stored with the same logic Events are stored
- Aggregate 'View' gets outdated when Aggregate logic changes, hence:
  - Calculate hash of 'Apply' method (and possibly of more dependencies, like properties)
  - Compare local hash to persisted hash
    - if equal: view is up to date, we can do a cheap 'point read' (in fact, we have already done it at that point)
    - else: view needs to be refreshed: rehydrate aggregate and store newest version