### PR TITLE
RecordTypeAttribute (second attempt)

### DIFF
--- a/EventSourcing.Core.Tests/EventStoreTests/EventStoreRecordAttributeTests.cs
+++ b/EventSourcing.Core.Tests/EventStoreTests/EventStoreRecordAttributeTests.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+using EventSourcing.Core.Tests.Mocks;
+
+namespace EventSourcing.Core.Tests;
+
+public abstract partial class EventStoreTests
+{
+    [Fact]
+    public async Task Can_Store_Attribute_Event_With_Correct_Type()
+    {
+        var e = new EmptyAggregate().Add(new AttributeEvent("something"));
+        var recordType = e.GetType().GetCustomAttribute<RecordType>()!.Value;
+
+        await EventStore.AddAsync(new List<Event>{e});
+        var result = await EventStore.Events
+            .Where(r => r.RecordId == e.RecordId && r.Type == recordType)
+            .AsAsyncEnumerable()
+            .FirstOrDefaultAsync() as AttributeEvent;
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Can_Deserialize_Attribute_Event_With_Custom_Type_Name()
+    {
+        var e = new EmptyAggregate().Add(new AttributeEvent("something"));
+
+        await EventStore.AddAsync(new List<Event>{e});
+
+        var result = await EventStore.Events
+            .Where(r => r.RecordId == e.RecordId)
+            .AsAsyncEnumerable()
+            .FirstOrDefaultAsync() as AttributeEvent;
+
+        Assert.NotNull(result);
+        Assert.Equal(typeof(AttributeEvent).GetCustomAttribute<RecordType>()!.Value, result!.Type);
+        Assert.Equal(e.SomeString, result.SomeString);
+    }
+}

--- a/EventSourcing.Core.Tests/Mocks/AttributeEvent.cs
+++ b/EventSourcing.Core.Tests/Mocks/AttributeEvent.cs
@@ -1,0 +1,4 @@
+namespace EventSourcing.Core.Tests.Mocks;
+
+[RecordType("CustomEventName")]
+public record AttributeEvent(string SomeString) : Event;

--- a/EventSourcing.Core.Tests/RecordConversionTests.cs
+++ b/EventSourcing.Core.Tests/RecordConversionTests.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using System.Text;
 using System.Text.Json;
-using EventSourcing.Core.Migrations;
 
 namespace EventSourcing.Core.Tests;
 

--- a/EventSourcing.Core/Attributes/RecordType.cs
+++ b/EventSourcing.Core/Attributes/RecordType.cs
@@ -1,0 +1,14 @@
+namespace EventSourcing.Core;
+
+public class RecordType : Attribute
+{
+    public string Value { get; }
+
+    public RecordType(string recordType)
+    {
+        if(string.IsNullOrWhiteSpace(recordType))
+            throw new ArgumentException("Record type cannot be white space", nameof(recordType));
+
+        Value = recordType;
+    }
+}

--- a/EventSourcing.Core/Migrators/RecordMigrator.cs
+++ b/EventSourcing.Core/Migrators/RecordMigrator.cs
@@ -14,7 +14,7 @@ public abstract class RecordMigrator<TSource, TTarget> : IRecordMigrator where T
   public Record Convert(Record record) =>
     Convert((TSource) record) with {
         Timestamp = record.Timestamp,
-        Type = typeof(TTarget).Name,
+        Type = RecordTypeCache.GetAssemblyRecordTypeString(Target),
         AggregateId = record.AggregateId,
         AggregateType = record.AggregateType,
         Index = record.Index,

--- a/EventSourcing.Core/Migrators/RecordMigratorService.cs
+++ b/EventSourcing.Core/Migrators/RecordMigratorService.cs
@@ -1,0 +1,52 @@
+namespace EventSourcing.Core.Migrations;
+
+public class RecordMigratorService
+{
+    private static List<Type> AssemblyMigratorTypes => AppDomain.CurrentDomain
+        .GetAssemblies()
+        .SelectMany(assembly => assembly.GetTypes())
+        .Where(type => typeof(IRecordMigrator).IsAssignableFrom(type) && type.IsClass && !type.IsAbstract && type.IsPublic)
+        .ToList();
+
+    private readonly Dictionary<Type, IRecordMigrator?> _migrators;
+
+    public RecordMigratorService(List<Type>? migratorTypes = null)
+    {
+        // Create dictionary mapping from Record.Type to Migrator Type
+        _migrators = (migratorTypes ?? AssemblyMigratorTypes)
+            .Select(type => Activator.CreateInstance(type) as IRecordMigrator)
+            .ToDictionary(migrator => migrator!.Source, migrator => migrator);
+
+        ValidateMigrators();
+    }
+
+    public Record Migrate(Record record)
+    {
+        while (_migrators.TryGetValue(record.GetType(), out var migrator))
+            record = migrator!.Convert(record);
+
+        return record;
+    }
+
+    private void ValidateMigrators()
+    {
+        var migrations = _migrators.Values.ToDictionary(x => x!.Source, x => x!.Target);
+
+        while (migrations.Count > 0)
+        {
+            var source = migrations.First().Key;
+            var visited = new List<Type> { source };
+
+            while (migrations.TryGetValue(source, out var target))
+            {
+                visited.Add(source);
+                migrations.Remove(source);
+
+                if (visited.Contains(target))
+                    throw new ArgumentException("Record Migrator Collection contains cyclic reference(s)");
+
+                source = target;
+            }
+        }
+    }
+}

--- a/EventSourcing.Core/Records/Record.cs
+++ b/EventSourcing.Core/Records/Record.cs
@@ -48,7 +48,7 @@ public record Record
   protected Record()
   {
     RecordId = Guid.NewGuid();
-    Type = GetType().Name;
+    Type = RecordTypeCache.GetAssemblyRecordTypeString(GetType());
     Timestamp = DateTimeOffset.Now;
   }
   

--- a/EventSourcing.Core/Records/RecordConverter.cs
+++ b/EventSourcing.Core/Records/RecordConverter.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using EventSourcing.Core.Migrations;
 
 namespace EventSourcing.Core;
@@ -11,60 +10,32 @@ namespace EventSourcing.Core;
 /// </remarks>
 public class RecordConverter<TRecord> : JsonConverter<TRecord> where TRecord : Record
 {
-  private static readonly List<Type> AssemblyRecordTypes = AppDomain.CurrentDomain
-    .GetAssemblies()
-    .SelectMany(x => x.GetTypes())
-    .Where(type => typeof(Record).IsAssignableFrom(type) && type.IsClass && !type.IsAbstract && type.IsPublic)
-    .ToList();
-
-  private static readonly List<Type> AssemblyMigratorTypes = AppDomain.CurrentDomain
-    .GetAssemblies()
-    .SelectMany(assembly => assembly.GetTypes())
-    .Where(type => typeof(IRecordMigrator).IsAssignableFrom(type) && type.IsClass && !type.IsAbstract && type.IsPublic)
-    .ToList();
-
-  private readonly RecordConverterOptions? _options;
-  private readonly Dictionary<string, Type> _recordTypes;
-  private readonly Dictionary<Type, PropertyInfo[]> _nonNullableRecordProperties;
-
-  private readonly Dictionary<string, IRecordMigrator> _migrators;
-
   private class RecordType
   {
     public string? Type { get; set; }
   }
+  
+  private readonly RecordTypeCache _recordTypeCache;
+  private readonly RecordMigratorService _recordMigratorService;
 
   public RecordConverter(RecordConverterOptions? options = null)
   {
-    _options = options;
-    
-    // Create dictionary mapping from Record.Type string to Record Type
-    _recordTypes = (options?.RecordTypes ?? AssemblyRecordTypes).ToDictionary(type => type.Name);
-    
-    // For each Record Type, create set of non-nullable properties for validation
-    _nonNullableRecordProperties = _recordTypes.Values.ToDictionary(type => type, type => type.GetProperties()
-      .Where(property => Nullable.GetUnderlyingType(property.PropertyType) == null).ToArray());
-    
-    // Create dictionary mapping from Record.Type to Migrator Type
-    _migrators = (options?.MigratorTypes ?? AssemblyMigratorTypes)
-      .Select(type => Activator.CreateInstance(type) as IRecordMigrator)
-      .ToDictionary(migrator => migrator!.Source.Name, migrator => migrator)!;
-
-    ValidateMigrators();
+    _recordTypeCache = new RecordTypeCache(options?.RecordTypes);
+    _recordMigratorService = new RecordMigratorService(options?.MigratorTypes);
   }
 
   /// <summary>
   /// Use <see cref="RecordConverter{TRecord}"/> for all Types inheriting from <see cref="Record"/>
   /// </summary>
   /// <param name="typeToConvert">Type to Convert</param>
-  public override bool CanConvert(Type typeToConvert) => typeof(Record).IsAssignableFrom(typeToConvert);
+  public override bool CanConvert(Type typeToConvert) => typeof(TRecord).IsAssignableFrom(typeToConvert);
 
   /// <summary>
   /// Serialize Record
   /// </summary>
   public override void Write(Utf8JsonWriter writer, TRecord value, JsonSerializerOptions options)
   {
-    var type = GetRecordType(value.Type);
+    var type = value.GetType();
     var record = Validate(value, type);
     JsonSerializer.Serialize(writer, record, type);
   }
@@ -75,14 +46,13 @@ public class RecordConverter<TRecord> : JsonConverter<TRecord> where TRecord : R
   /// <exception cref="JsonException">Thrown when <see cref="Record"/> type cannot be found.</exception>
   public override TRecord Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
   {
-    var type = GetRecordType(reader);
-    var record = JsonSerializer.Deserialize(ref reader, type) as TRecord 
-                 ?? throw new JsonException($"Error Converting Json to {type}.");
-
-    return Migrate(Validate(record, type));
+    var type = DeserializeRecordType(reader);
+    var record = JsonSerializer.Deserialize(ref reader, type) as Record
+                 ?? throw new JsonException($"Error Converting Json to {type.Name}.");
+    return (TRecord) _recordMigratorService.Migrate(Validate(record, type));
   }
 
-  private Type GetRecordType(Utf8JsonReader reader)
+  private Type DeserializeRecordType(Utf8JsonReader reader)
   {
     // Get Record.Type String from Json
     var typeString = JsonSerializer.Deserialize<RecordType>(ref reader)?.Type ??
@@ -93,25 +63,12 @@ public class RecordConverter<TRecord> : JsonConverter<TRecord> where TRecord : R
          $"Couldn't parse {typeof(TRecord)}.Type string from Json. " +
          $"Does the Json contain a {nameof(Record.Type)} field?");
 
-    return GetRecordType(typeString);
+    return _recordTypeCache.GetRecordType(typeString);
   }
 
-  private Type GetRecordType(string typeString)
+  private Record Validate(Record record, Type type)
   {
-    // Get Record Type from Dictionary
-    if (_recordTypes.TryGetValue(typeString, out var type)) return type;
-
-    if (_options?.MigratorTypes == null)
-      throw new InvalidOperationException(
-        $"Error Converting {typeof(TRecord)}. {typeof(TRecord)} with type '{typeString}' not found in Assembly. Ensure {typeof(TRecord)} with type '{typeString}' is a public non-nested type");
-    else
-      throw new InvalidOperationException(
-        $"Error Converting {typeof(TRecord)}. {typeof(TRecord)} with type '{typeString}' not found in {nameof(RecordConverterOptions)}.{nameof(RecordConverterOptions.RecordTypes)}. Ensure {typeof(TRecord)} with type '{typeString}' is included.");
-  }
-
-  private TRecord Validate(TRecord record, Type type)
-  {
-    var missing = _nonNullableRecordProperties[type]
+    var missing = _recordTypeCache.GetNonNullableRecordProperties(type)
       .Where(property => property.GetValue(record) == null)
       .Select(property => property.Name)
       .ToList();
@@ -123,35 +80,5 @@ public class RecordConverter<TRecord> : JsonConverter<TRecord> where TRecord : R
         $"Either make properties nullable or use a RecordMigrator to handle {nameof(TRecord)} versioning.");
 
     return record;
-  }
-
-  private TRecord Migrate(TRecord record)
-  {
-    while (_migrators.TryGetValue(record.Type, out var migrator))
-      record = (TRecord) migrator.Convert(record);
-
-    return record;
-  }
-  
-  private void ValidateMigrators()
-  {
-    var migrations = _migrators.Values.ToDictionary(x => x.Source, x => x.Target);
-
-    while (migrations.Count > 0)
-    {
-      var source = migrations.First().Key;
-      var visited = new List<Type> { source };
-      
-      while (migrations.TryGetValue(source, out var target))
-      {
-        visited.Add(source);
-        migrations.Remove(source);
-        
-        if (visited.Contains(target))
-          throw new ArgumentException("Record Migrator Collection contains cyclic reference(s)");
-        
-        source = target;
-      }
-    }
   }
 }

--- a/EventSourcing.Core/Records/RecordTypeCache.cs
+++ b/EventSourcing.Core/Records/RecordTypeCache.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+
+namespace EventSourcing.Core;
+
+public sealed class RecordTypeCache
+{
+    // Static RecordTypes cache
+    private static readonly List<Type> AssemblyRecordTypes = AppDomain.CurrentDomain
+        .GetAssemblies()
+        .SelectMany(x => x.GetTypes())
+        .Where(type => typeof(Record).IsAssignableFrom(type) && type.IsClass && !type.IsAbstract)
+        .ToList();
+    private static readonly Dictionary<Type, string> RecordTypeStrings =
+        AssemblyRecordTypes.ToDictionary(type => type, type => type.GetCustomAttribute<RecordType>()?.Value ?? type.Name);
+
+    // Non-static RecordTypes cache
+    private readonly Dictionary<string, Type> _recordTypes;
+    private readonly Dictionary<Type, string> _recordTypeStrings;
+    private readonly Dictionary<Type, PropertyInfo[]> _nonNullableRecordProperties;
+
+    public RecordTypeCache(IReadOnlyCollection<Type>? recordTypes)
+    {
+        // Create dictionaries mapping from Record.Type string to Record Type and it's reverse
+        _recordTypeStrings = recordTypes == null ? 
+            RecordTypeStrings : recordTypes.ToDictionary(type => type, type => type.GetCustomAttribute<RecordType>()?.Value ?? type.Name);
+        _recordTypes = _recordTypeStrings.ToDictionary(kv => kv.Value, kv => kv.Key);
+        // For each Record Type, create set of non-nullable properties for validation
+        _nonNullableRecordProperties = _recordTypes.Values.ToDictionary(type => type, type => type.GetProperties()
+            .Where(property => Nullable.GetUnderlyingType(property.PropertyType) == null).ToArray());
+    }
+    public Type GetRecordType(string typeString)
+    {
+        if (!_recordTypes.TryGetValue(typeString, out var type))
+            throw new InvalidOperationException(
+                $"Error getting record type string for {type}. {type} not provided in {nameof(RecordTypeCache)}.ctor");
+
+        return type;
+    }
+    public string GetRecordTypeString(Type type)
+    {
+        if(!_recordTypeStrings.TryGetValue(type, out var typeString))
+            throw new InvalidOperationException(
+                $"Error getting record type string for {type}. {type} not provided in {nameof(RecordTypeCache)}.ctor");
+
+        return typeString;
+    }
+    public static string GetAssemblyRecordTypeString(Type type)
+    {
+        if(!RecordTypeStrings.TryGetValue(type, out var typeString))
+            throw new InvalidOperationException(
+                $"Error getting record type string for {type}. {type} not found in Assembly. Ensure {type.Name} extends {typeof(Record)}");
+
+        return typeString;
+    }
+    public IEnumerable<PropertyInfo> GetNonNullableRecordProperties(Type type)
+    {
+        if(!_nonNullableRecordProperties.TryGetValue(type, out var properties))
+            throw new InvalidOperationException($"Error getting non-nullable properties for {type}. {type} not provided in {nameof(RecordTypeCache)}.ctor");
+
+        return properties;
+    }
+}

--- a/EventSourcing.Core/Records/RecordValidation.cs
+++ b/EventSourcing.Core/Records/RecordValidation.cs
@@ -36,9 +36,6 @@ public static class RecordValidation
 
   public static void ValidateRecord(Record r)
   {
-    if (r.Type != r.GetType().Name)
-      Throw(r, $"{r.GetType().Name}.Type ({r.Type}) should equal typeof({r.GetType().Name}).Name ({r.GetType().Name})");
-    
     if (r.AggregateId == Guid.Empty)
       Throw(r, $"{r.Type}.AggregateId should not be Guid.Empty");
     
@@ -50,6 +47,11 @@ public static class RecordValidation
     
     if (r.Index < 0)
       Throw(r, $"{r.Type}.Index ({r.Index}) must be a non-negative integer");
+    
+    var typeString = RecordTypeCache.GetAssemblyRecordTypeString(r.GetType());
+
+    if(r.Type != typeString)
+      Throw(r, $"{r.GetType().Name}.Type ({r.Type}) should equal to {typeString}");
   }
 
   public static void ValidateSnapshotForAggregate(Aggregate a, Snapshot s)


### PR DESCRIPTION
In this PR:

- Migrator logic now has its own class
- RecordTypeCache provides cached dictionaries to find correct Record.Type corresponding to Record.GetType() and vice versa.
- RecordTypeCache contains a static dictionary based on types found in entire assembly for when it has not yet been initialized
- RecordTypeAttribute for when a custom Record.Type is needed (different from Record.GetType().Name)
- Simple tests for custom record types
