### PR TITLE
Preserve consecutive Event ordering in EF inserts

### DIFF
--- a/EventSourcing.Core.Tests/AggregateServiceTests/PersistAsync.cs
+++ b/EventSourcing.Core.Tests/AggregateServiceTests/PersistAsync.cs
@@ -160,13 +160,17 @@ public abstract partial class EventSourcingTests
   [Fact] // Tests issue https://github.com/Finaps/EventSourcing/issues/72
   public async Task AggregateService_PersistAsync_NonAlphabetical_Events_Persisted_In_Order()
   {
-    var aggregate = new BankAccount();
-    aggregate.Apply(new BankAccountCreatedEvent("E. Sourcing", "Some IBAN"));
-    aggregate.Apply(new BankAccountFundsDepositedEvent(500));
-    aggregate.Apply(new BankAccountFundsWithdrawnEvent(100));
-    aggregate.Apply(new BankAccountFundsDepositedEvent(50));
-    aggregate.Apply(new BankAccountFundsWithdrawnEvent(20));
-    aggregate.Apply(new BankAccountFundsDepositedEvent(500));
-    await AggregateService.PersistAsync(aggregate);
+    var bankAccount = new BankAccount();
+    var bankAccount2 = new BankAccount();
+
+    bankAccount.Apply(new BankAccountCreatedEvent("E. Sourcing", "Some IBAN"));
+    bankAccount2.Apply(new BankAccountCreatedEvent("Other Person", "Some other IBAN"));
+    
+    bankAccount.Apply(new BankAccountFundsDepositedEvent(500));
+    bankAccount.Apply(new BankAccountFundsWithdrawnEvent(100));
+    bankAccount.Apply(new BankAccountFundsTransferredEvent(50, bankAccount.Id, bankAccount2.Id));
+    bankAccount.Apply(new BankAccountFundsWithdrawnEvent(20));
+    bankAccount.Apply(new BankAccountFundsDepositedEvent(500));
+    await AggregateService.PersistAsync(bankAccount);
   }
 }

--- a/EventSourcing.Core.Tests/AggregateServiceTests/PersistAsync.cs
+++ b/EventSourcing.Core.Tests/AggregateServiceTests/PersistAsync.cs
@@ -156,4 +156,17 @@ public abstract partial class EventSourcingTests
     Assert.NotNull(snapshotResult);
     Assert.Equal((int) factory.SnapshotInterval, eventCount);
   }
+
+  [Fact] // Tests issue https://github.com/Finaps/EventSourcing/issues/72
+  public async Task AggregateService_PersistAsync_NonAlphabetical_Events_Persisted_In_Order()
+  {
+    var aggregate = new BankAccount();
+    aggregate.Apply(new BankAccountCreatedEvent("E. Sourcing", "Some IBAN"));
+    aggregate.Apply(new BankAccountFundsDepositedEvent(500));
+    aggregate.Apply(new BankAccountFundsWithdrawnEvent(100));
+    aggregate.Apply(new BankAccountFundsDepositedEvent(50));
+    aggregate.Apply(new BankAccountFundsWithdrawnEvent(20));
+    aggregate.Apply(new BankAccountFundsDepositedEvent(500));
+    await AggregateService.PersistAsync(aggregate);
+  }
 }

--- a/EventSourcing.Core.Tests/RecordStoreTests/DeleteAggregateAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/DeleteAggregateAsync.cs
@@ -84,22 +84,24 @@ public abstract partial class EventSourcingTests
   [Fact]
   public async Task RecordStore_DeleteAggregateAsync_Can_Delete_More_Than_100_Events()
   {
+    var store = RecordStore;
+    
     var aggregate = new EmptyAggregate();
     var events = new List<Event>();
 
     for (var i = 0; i < 100; i++)
       events.Add(aggregate.Apply(new EmptyEvent()));
 
-    await RecordStore.AddEventsAsync(events);
+    await store.AddEventsAsync(events);
     events.Clear();
 
     for (var i = 0; i < 10; i++)
       events.Add(aggregate.Apply(new EmptyEvent()));
 
-    await RecordStore.AddEventsAsync(events);
-    var deleted = await RecordStore.DeleteAggregateAsync<EmptyAggregate>(Guid.Empty, aggregate.Id);
+    await store.AddEventsAsync(events);
+    var deleted = await store.DeleteAggregateAsync<EmptyAggregate>(Guid.Empty, aggregate.Id);
 
-    var count = await RecordStore
+    var count = await store
       .GetEvents<EmptyAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()

--- a/EventSourcing.Core.Tests/RecordStoreTests/DeleteAllSnapshotsAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/DeleteAllSnapshotsAsync.cs
@@ -7,17 +7,19 @@ public abstract partial class EventSourcingTests
     [Fact]
     public async Task RecordStore_DeleteAllSnapshotsAsync_Can_Delete_Snapshots()
     {
+        var store = RecordStore;
+        
         var aggregate = new SnapshotAggregate();
         var factory = new SimpleSnapshotFactory();
         foreach (var _ in Enumerable.Range(0, 3))
         {
             var e = aggregate.Apply(new SnapshotEvent());
-            await RecordStore.AddEventsAsync(new List<Event> { e });
+            await store.AddEventsAsync(new List<Event> { e });
             var snapshot = factory.CreateSnapshot(aggregate);
-            await RecordStore.AddSnapshotAsync(snapshot);
+            await store.AddSnapshotAsync(snapshot);
         }
 
-        var countBeforeDelete = await RecordStore
+        var countBeforeDelete = await store
             .GetSnapshots<SnapshotAggregate>()
             .Where(x => x.AggregateId == aggregate.Id)
             .AsAsyncEnumerable()
@@ -25,9 +27,9 @@ public abstract partial class EventSourcingTests
         
         Assert.Equal(3, countBeforeDelete);
 
-        await RecordStore.DeleteAllSnapshotsAsync<SnapshotAggregate>(aggregate.Id);
+        await store.DeleteAllSnapshotsAsync<SnapshotAggregate>(aggregate.Id);
         
-        var countAfterDelete = await RecordStore
+        var countAfterDelete = await store
             .GetSnapshots<SnapshotAggregate>()
             .Where(x => x.AggregateId == aggregate.Id)
             .AsAsyncEnumerable()
@@ -78,19 +80,21 @@ public abstract partial class EventSourcingTests
     [Fact]
     public async Task RecordStore_DeleteAllSnapshotsAsync_Correctly_Returns_Deleted_Count()
     {
+        var store = RecordStore;
+        
         var aggregate = new SnapshotAggregate();
         var factory = new SimpleSnapshotFactory();
         foreach (var _ in Enumerable.Range(0, 3))
         {
             var e = aggregate.Apply(new SnapshotEvent());
-            await RecordStore.AddEventsAsync(new List<Event> { e });
+            await store.AddEventsAsync(new List<Event> { e });
             var snapshot = factory.CreateSnapshot(aggregate);
-            await RecordStore.AddSnapshotAsync(snapshot);
+            await store.AddSnapshotAsync(snapshot);
         }
         
-        var deleted = await RecordStore.DeleteAllSnapshotsAsync<SnapshotAggregate>(aggregate.Id);
+        var deleted = await store.DeleteAllSnapshotsAsync<SnapshotAggregate>(aggregate.Id);
         
-        var countAfterDelete = await RecordStore
+        var countAfterDelete = await store
             .GetSnapshots<SnapshotAggregate>()
             .Where(x => x.AggregateId == aggregate.Id)
             .AsAsyncEnumerable()

--- a/EventSourcing.Core.Tests/RecordStoreTests/GetSnapshots.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/GetSnapshots.cs
@@ -1,5 +1,3 @@
-using Finaps.EventSourcing.Core.Tests.Mocks;
-
 namespace Finaps.EventSourcing.Core.Tests;
 
 public abstract partial class EventSourcingTests
@@ -47,21 +45,24 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = new SnapshotAggregate();
     var e1 = aggregate.Apply(new SnapshotEvent());
-    await RecordStore.AddEventsAsync(new List<Event> { e1 });
+
+    var store = RecordStore;
+
+    await store.AddEventsAsync(new List<Event> { e1 });
     
     var factory = new SimpleSnapshotFactory();
     
     var snapshot1 = factory.CreateSnapshot(aggregate);
     
     var e2 = aggregate.Apply(new SnapshotEvent());
-    await RecordStore.AddEventsAsync(new List<Event> { e2 });
+    await store.AddEventsAsync(new List<Event> { e2 });
     
     var snapshot2 = factory.CreateSnapshot(aggregate);
 
     Assert.NotEqual(snapshot1.Index, snapshot2.Index);
 
-    await RecordStore.AddSnapshotAsync(snapshot1);
-    await RecordStore.AddSnapshotAsync(snapshot2);
+    await store.AddSnapshotAsync(snapshot1);
+    await store.AddSnapshotAsync(snapshot2);
 
     var result = await RecordStore
       .GetSnapshots<SnapshotAggregate>()

--- a/EventSourcing.Core/Aggregate.cs
+++ b/EventSourcing.Core/Aggregate.cs
@@ -138,7 +138,11 @@ public abstract class Aggregate<TAggregate> : Aggregate where TAggregate : Aggre
       PartitionId = PartitionId,
       AggregateId = Id,
       AggregateType = Type,
-      Index = Version
+      Index = Version,
+      
+      // Set Previous Event Reference to convince EF Core about Event consecutiveness
+      // See https://github.com/Finaps/EventSourcing/issues/72
+      _previousEvent = UncommittedEvents.Cast<Event<TAggregate>>().LastOrDefault()
     };
     
     ValidateAndApply(e);

--- a/EventSourcing.Core/Records/Event.cs
+++ b/EventSourcing.Core/Records/Event.cs
@@ -23,4 +23,6 @@ public record Event<TAggregate> : Event where TAggregate : Aggregate, new()
 {
   /// <inheritdoc />
   public Event() => AggregateType = typeof(TAggregate).Name;
+  
+  internal Event<TAggregate>? _previousEvent { get; set; }
 }

--- a/EventSourcing.EF/EntityFrameworkRecordTransaction.cs
+++ b/EventSourcing.EF/EntityFrameworkRecordTransaction.cs
@@ -90,51 +90,54 @@ public class EntityFrameworkRecordTransaction : IRecordTransaction
   /// <inheritdoc />
   public async Task CommitAsync(CancellationToken cancellationToken = default)
   {
-    foreach (var action in _actions)
-    {
-      switch (action)
-      {
-        case AddEventsAction(var events):
-          _store.Context.AddRange(events);
-          break;
-
-        case AddSnapshotAction(var snapshot):
-          _store.Context.Add(snapshot);
-          break;
-
-        case UpsertProjectionAction(var projection):
-
-          // Since EF Core has no Upsert functionality, we have to first query the original Projection :(
-          var existing = await _store.Context.FindAsync(
-            projection.GetType(),
-            projection.PartitionId, projection.AggregateId);
-
-          // Remove instead of update: this fixes problems with owned entities
-          if (existing != null) _store.Context.Remove(existing);
-
-          _store.Context.Add(projection);
-
-          break;
-
-        case DeleteAllEventsAction(var e):
-          await _store.Context.DeleteWhereAsync($"{e.AggregateType}{nameof(Event)}s", PartitionId, e.AggregateId, cancellationToken);
-          break;
-
-        case DeleteSnapshotAction(var snapshot):
-          _store.Context.Attach(snapshot);
-          _store.Context.Remove(snapshot);
-          break;
-
-        case DeleteProjectionAction(var projection):
-          _store.Context.Attach(projection);
-          _store.Context.Remove(projection);
-          break;
-      }
-    }
-
     try
     {
+      await using var transaction = await _store.Context.Database.BeginTransactionAsync(cancellationToken);
+      
+      foreach (var action in _actions)
+      {
+        switch (action)
+        {
+          case AddEventsAction(var events):
+            _store.Context.AddRange(events);
+            break;
+
+          case AddSnapshotAction(var snapshot):
+            _store.Context.Add(snapshot);
+            break;
+
+          case UpsertProjectionAction(var projection):
+
+            // Since EF Core has no Upsert functionality, we have to first query the original Projection :(
+            var existing = await _store.Context.FindAsync(
+              projection.GetType(),
+              projection.PartitionId, projection.AggregateId);
+
+            // Remove instead of update: this fixes problems with owned entities
+            if (existing != null) _store.Context.Remove(existing);
+
+            _store.Context.Add(projection);
+
+            break;
+
+          case DeleteAllEventsAction(var e):
+            await _store.Context.DeleteWhereAsync($"{e.AggregateType}{nameof(Event)}s", PartitionId, e.AggregateId, cancellationToken);
+            break;
+
+          case DeleteSnapshotAction(var snapshot):
+            _store.Context.Attach(snapshot);
+            _store.Context.Remove(snapshot);
+            break;
+
+          case DeleteProjectionAction(var projection):
+            _store.Context.Attach(projection);
+            _store.Context.Remove(projection);
+            break;
+        }
+      }
+    
       await _store.Context.SaveChangesAsync(cancellationToken);
+      await transaction.CommitAsync(cancellationToken);
     }
     catch (DbUpdateException e)
     {

--- a/EventSourcing.EF/EntityFrameworkRecordTransaction.cs
+++ b/EventSourcing.EF/EntityFrameworkRecordTransaction.cs
@@ -90,8 +90,7 @@ public class EntityFrameworkRecordTransaction : IRecordTransaction
   /// <inheritdoc />
   public async Task CommitAsync(CancellationToken cancellationToken = default)
   {
-    try
-    {
+
       await using var transaction = await _store.Context.Database.BeginTransactionAsync(cancellationToken);
       
       foreach (var action in _actions)
@@ -135,13 +134,15 @@ public class EntityFrameworkRecordTransaction : IRecordTransaction
             break;
         }
       }
-    
-      await _store.Context.SaveChangesAsync(cancellationToken);
-      await transaction.CommitAsync(cancellationToken);
-    }
-    catch (DbUpdateException e)
-    {
-      throw new RecordStoreException(e.Message, e);
-    }
+
+      try
+      {
+        await _store.Context.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+      }
+      catch (DbUpdateException e)
+      {
+        throw new RecordStoreException(e.Message, e);
+      }
   }
 }


### PR DESCRIPTION
The EF Core ```DbContext.Add``` and ```DbContext.AddRange``` methods sort entries alphabetically instead of preserving insertion order. This leads to violations in the ```ConsecutiveIndex``` constraint in Postgres. This error does not happen in SQL Server. (why not?)

By referencing the previous Event in Applied Events, EF Core can figure out the dependencies between events and correctly preserve the insertion order.

Alternative strategies to fix this issue:
- Call DbContext.Add + DbContext.SaveChangesAsync for every added Event
  - Very slow, since it requires many round trips to the Database
- Use a Bulk Insert Library that does preserve insertion order
  - We have to keep the licensing and maintenance in mind when choosing to do so
- Write custom Bulk Insert Library that does preserve insertion order
  - Will fix this issue and improve performance, but requires many tests to cover all cases.
- Investigate why SQL Server does work and see if the same configuration can be applied for Postgres