### PR TITLE
Update Generic Interface

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       run: dotnet restore
 
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore -warnaserror
       
     - name: Install Entity Framework Tool
       run: |

--- a/EventSourcing.Core.Tests/AggregateTransactionTests/AddAggregateAsync.cs
+++ b/EventSourcing.Core.Tests/AggregateTransactionTests/AddAggregateAsync.cs
@@ -47,7 +47,7 @@ public abstract partial class EventSourcingTests
     await transaction.AddAggregateAsync(aggregate2);
 
     // Sneakily commit first event of first aggregate before committing transaction
-    await RecordStore.AddEventsAsync(new List<Event<SimpleAggregate>> { e });
+    await RecordStore.AddEventsAsync(new [] { e });
 
     await Assert.ThrowsAsync<RecordStoreException>(async () => await transaction.CommitAsync());
 

--- a/EventSourcing.Core.Tests/AggregateTransactionTests/AddAggregateAsync.cs
+++ b/EventSourcing.Core.Tests/AggregateTransactionTests/AddAggregateAsync.cs
@@ -47,7 +47,7 @@ public abstract partial class EventSourcingTests
     await transaction.AddAggregateAsync(aggregate2);
 
     // Sneakily commit first event of first aggregate before committing transaction
-    await RecordStore.AddEventsAsync(new List<Event> { e });
+    await RecordStore.AddEventsAsync(new List<Event<SimpleAggregate>> { e });
 
     await Assert.ThrowsAsync<RecordStoreException>(async () => await transaction.CommitAsync());
 

--- a/EventSourcing.Core.Tests/BankAccountScenarioTests.cs
+++ b/EventSourcing.Core.Tests/BankAccountScenarioTests.cs
@@ -63,7 +63,10 @@ public abstract partial class EventSourcingTests
     account.Apply(transfer);
     anotherAccount.Apply(transfer);
 
-    await AggregateService.PersistAsync(new[] { account, anotherAccount });
+    var transaction = AggregateService.CreateTransaction();
+    await transaction.AddAggregateAsync(account);
+    await transaction.AddAggregateAsync(anotherAccount);
+    await transaction.CommitAsync();
 
     var result1 = await AggregateService.RehydrateAsync<BankAccount>(account.Id);
     var result2 = await AggregateService.RehydrateAsync<BankAccount>(anotherAccount.Id);

--- a/EventSourcing.Core.Tests/Mocks/MockAggregateServiceSubclass.cs
+++ b/EventSourcing.Core.Tests/Mocks/MockAggregateServiceSubclass.cs
@@ -12,28 +12,28 @@ public class MockAggregateTransactionSubclass : AggregateTransaction
   
   public MockAggregateTransactionSubclass(IRecordTransaction recordTransaction) : base(recordTransaction) { }
 
-  public override Task<IAggregateTransaction> AddAggregateAsync(Aggregate aggregate)
+  public override Task<IAggregateTransaction> AddAggregateAsync<TAggregate>(TAggregate aggregate, CancellationToken cancellationToken = default)
   {
     AddAggregateAsyncCallCount++;
-    return base.AddAggregateAsync(aggregate);
+    return base.AddAggregateAsync(aggregate, cancellationToken);
   }
 
-  protected override Task AddEventsAsync(List<Event> events)
+  protected override Task AddEventsAsync<TAggregate>(List<Event<TAggregate>> events, CancellationToken cancellationToken = default)
   {
     AddEventsAsyncCallCount++;
-    return base.AddEventsAsync(events);
+    return base.AddEventsAsync(events, cancellationToken);
   }
 
-  protected override Task AddSnapshotAsync(Snapshot snapshot)
+  protected override Task AddSnapshotAsync<TAggregate>(Snapshot<TAggregate> snapshot, CancellationToken cancellationToken = default)
   {
     AddSnapshotAsyncCallCount++;
-    return base.AddSnapshotAsync(snapshot);
+    return base.AddSnapshotAsync(snapshot, cancellationToken);
   }
 
-  protected override Task UpsertProjectionAsync(Projection projection)
+  protected override Task UpsertProjectionAsync(Projection projection, CancellationToken cancellationToken = default)
   {
     UpsertProjectionAsyncCallCount++;
-    return base.UpsertProjectionAsync(projection);
+    return base.UpsertProjectionAsync(projection, cancellationToken);
   }
 
   public override Task CommitAsync(CancellationToken cancellationToken = default)

--- a/EventSourcing.Core.Tests/RecordStoreTests/AddEventsAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/AddEventsAsync.cs
@@ -5,32 +5,31 @@ public abstract partial class EventSourcingTests
   [Fact]
   public async Task RecordStore_AddEventsAsync_Can_Add_Single_Event()
   {
-    await RecordStore.AddEventsAsync(new Event[] { new EmptyAggregate().Apply(new EmptyEvent()) });
+    await RecordStore.AddEventsAsync(new [] { new EmptyAggregate().Apply(new EmptyEvent()) });
   }
 
   [Fact]
   public async Task RecordStore_AddEventsAsync_Can_Add_Multiple_Events()
   {
     var aggregate = new EmptyAggregate();
-    var events = new List<Event>();
-
-    for (var i = 0; i < 10; i++)
-      events.Add(aggregate.Apply(new EmptyEvent()));
-
+    var events = Enumerable
+      .Range(0, 10)
+      .Select(_ => aggregate.Apply(new EmptyEvent()))
+      .ToArray();
     await RecordStore.AddEventsAsync(events);
   }
 
   [Fact]
   public async Task RecordStore_AddEventsAsync_Can_Add_Empty_List()
   {
-    await RecordStore.AddEventsAsync(Array.Empty<Event>());
+    await RecordStore.AddEventsAsync(Array.Empty<Event<EmptyAggregate>>());
   }
 
   [Fact]
   public async Task RecordStore_AddEventsAsync_Cannot_Add_Null()
   {
     await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-      await RecordStore.AddEventsAsync(null!));
+      await RecordStore.AddEventsAsync<EmptyAggregate>(null!));
   }
   
   [Fact]
@@ -43,7 +42,7 @@ public abstract partial class EventSourcingTests
     e2 = e2 with { Index = 0 };
 
     await Assert.ThrowsAnyAsync<RecordValidationException>(
-      async () => await RecordStore.AddEventsAsync(new Event[] { e1, e2 }));
+      async () => await RecordStore.AddEventsAsync(new [] { e1, e2 }));
   }
   
   [Fact]
@@ -52,12 +51,12 @@ public abstract partial class EventSourcingTests
     var aggregate = new EmptyAggregate();
     var e1 = aggregate.Apply(new EmptyEvent());
 
-    await RecordStore.AddEventsAsync(new Event[] { e1 });
+    await RecordStore.AddEventsAsync(new [] { e1 });
     
     var e2 = aggregate.Apply(new EmptyEvent()) with { Index = 0 };
 
     await Assert.ThrowsAnyAsync<RecordStoreException>(
-      async () => await RecordStore.AddEventsAsync(new Event[] { e2 }));
+      async () => await RecordStore.AddEventsAsync(new [] { e2 }));
   }
 
   [Fact]
@@ -70,7 +69,7 @@ public abstract partial class EventSourcingTests
     var event2 = aggregate2.Apply(new EmptyEvent());
 
     await Assert.ThrowsAnyAsync<RecordValidationException>(
-      async () => await RecordStore.AddEventsAsync(new Event[] { event1, event2 }));
+      async () => await RecordStore.AddEventsAsync(new [] { event1, event2 }));
   }
 
   [Fact]
@@ -81,7 +80,7 @@ public abstract partial class EventSourcingTests
     var e2 = aggregate.Apply(new EmptyEvent()) with { Index = 2 };
 
     await Assert.ThrowsAnyAsync<RecordValidationException>(
-      async () => await RecordStore.AddEventsAsync(new Event[] { e1, e2 }));
+      async () => await RecordStore.AddEventsAsync(new [] { e1, e2 }));
   }
   
   [Fact]
@@ -90,12 +89,12 @@ public abstract partial class EventSourcingTests
     var aggregate = new EmptyAggregate();
     var e1 = aggregate.Apply(new EmptyEvent());
 
-    await RecordStore.AddEventsAsync(new Event[] { e1 });
+    await RecordStore.AddEventsAsync(new Event<EmptyAggregate>[] { e1 });
     
     var e2 = aggregate.Apply(new EmptyEvent()) with { Index = 2 };
 
     await Assert.ThrowsAnyAsync<RecordStoreException>(
-      async () => await RecordStore.AddEventsAsync(new Event[] { e2 }));
+      async () => await RecordStore.AddEventsAsync(new [] { e2 }));
   }
   
   [Fact]
@@ -105,7 +104,7 @@ public abstract partial class EventSourcingTests
     var e = aggregate.Apply(new EmptyEvent()) with { Index = -1 };
     
     await Assert.ThrowsAnyAsync<RecordValidationException>(
-      async () => await RecordStore.AddEventsAsync(new Event[] { e }));
+      async () => await RecordStore.AddEventsAsync(new [] { e }));
   }
   
   [Fact]
@@ -115,7 +114,7 @@ public abstract partial class EventSourcingTests
     var e = aggregate.Apply(new EmptyEvent()) with { Type = null! };
     
     await Assert.ThrowsAnyAsync<RecordValidationException>(
-      async () => await RecordStore.AddEventsAsync(new Event[] { e }));
+      async () => await RecordStore.AddEventsAsync(new [] { e }));
   }
   
   [Fact]
@@ -125,6 +124,6 @@ public abstract partial class EventSourcingTests
     var e = aggregate.Apply(new EmptyEvent()) with { AggregateType = null };
     
     await Assert.ThrowsAnyAsync<RecordValidationException>(
-      async () => await RecordStore.AddEventsAsync(new Event[] { e }));
+      async () => await RecordStore.AddEventsAsync(new [] { e }));
   }
 }

--- a/EventSourcing.Core.Tests/RecordStoreTests/AddSnapshotAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/AddSnapshotAsync.cs
@@ -7,7 +7,7 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = new SnapshotAggregate();
     var e = aggregate.Apply(new SnapshotEvent());
-    await RecordStore.AddEventsAsync(new List<Event> { e });
+    await RecordStore.AddEventsAsync(new [] { e });
     
     var factory = new SimpleSnapshotFactory();
     
@@ -19,7 +19,7 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = new SnapshotAggregate();
     var e = aggregate.Apply(new SnapshotEvent());
-    await RecordStore.AddEventsAsync(new List<Event> { e });
+    await RecordStore.AddEventsAsync(new [] { e });
 
     var factory = new SimpleSnapshotFactory();
 

--- a/EventSourcing.Core.Tests/RecordStoreTests/DeleteAggregateAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/DeleteAggregateAsync.cs
@@ -6,7 +6,7 @@ public abstract partial class EventSourcingTests
   public async Task RecordStore_DeleteAggregateAsync_Can_Delete_Events_With_DeleteAggregateAll()
   {
     var aggregate = new EmptyAggregate();
-    var events = new List<Event>();
+    var events = new List<Event<EmptyAggregate>>();
 
     for (var i = 0; i < 3; i++)
       events.Add(aggregate.Apply(new EmptyEvent()));
@@ -32,7 +32,7 @@ public abstract partial class EventSourcingTests
 
     // Store event
     var e = aggregate.Apply(new EmptyEvent());
-    await RecordStore.AddEventsAsync(new List<Event> { e });
+    await RecordStore.AddEventsAsync(new Event<EmptyAggregate>[] { e });
     Assert.NotNull(await RecordStore
       .GetEvents<EmptyAggregate>()
       .Where(x => x.AggregateId == e.AggregateId)
@@ -85,10 +85,11 @@ public abstract partial class EventSourcingTests
     var store = RecordStore;
     
     var aggregate = new EmptyAggregate();
-    var events = new List<Event>();
 
-    for (var i = 0; i < 100; i++)
-      events.Add(aggregate.Apply(new EmptyEvent()));
+    var events = Enumerable
+      .Range(0, 100)
+      .Select(_ => aggregate.Apply(new EmptyEvent()))
+      .ToList();
 
     await store.AddEventsAsync(events);
     events.Clear();

--- a/EventSourcing.Core.Tests/RecordStoreTests/DeleteAllEventsAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/DeleteAllEventsAsync.cs
@@ -6,10 +6,11 @@ public abstract partial class EventSourcingTests
   public async Task RecordStore_DeleteAllEventsAsync_Can_Delete_Events()
   {
     var aggregate = new EmptyAggregate();
-    var events = new List<Event>();
-
-    for (var i = 0; i < 10; i++)
-      events.Add(aggregate.Apply(new EmptyEvent()));
+    
+    var events = Enumerable
+      .Range(0, 10)
+      .Select(_ => aggregate.Apply(new EmptyEvent()))
+      .ToArray();
 
     await RecordStore.AddEventsAsync(events);
 
@@ -28,12 +29,13 @@ public abstract partial class EventSourcingTests
   public async Task RecordStore_DeleteAllEventsAsync_Deleting_Events_Does_Not_Delete_Projection()
   {
     var aggregate = new EmptyAggregate();
-    var events = new List<Event>();
     var snapshot = new EmptySnapshot { AggregateId = aggregate.Id, AggregateType = nameof(EmptyAggregate)};
     var projection = new EmptyProjection { AggregateId = aggregate.Id, AggregateType = nameof(EmptyAggregate), Hash = "RANDOM"};
 
-    for (var i = 0; i < 3; i++)
-      events.Add(aggregate.Apply(new EmptyEvent()));
+    var events = Enumerable
+      .Range(0, 3)
+      .Select(_ => aggregate.Apply(new EmptyEvent()))
+      .ToArray();
     
     await RecordStore.AddEventsAsync(events);
     await RecordStore.AddSnapshotAsync(snapshot);
@@ -57,11 +59,12 @@ public abstract partial class EventSourcingTests
   public async Task RecordStore_DeleteAllEventsAsync_Correctly_Returns_Deleted_Count()
   {
     var aggregate = new EmptyAggregate();
-    var events = new List<Event>();
-
-    for (var i = 0; i < 10; i++)
-      events.Add(aggregate.Apply(new EmptyEvent()));
-
+    
+    var events = Enumerable
+      .Range(0, 10)
+      .Select(_ => aggregate.Apply(new EmptyEvent()))
+      .ToArray();
+    
     await RecordStore.AddEventsAsync(events);
 
     var deleted = await RecordStore.DeleteAllEventsAsync<EmptyAggregate>(aggregate.Id);
@@ -73,6 +76,6 @@ public abstract partial class EventSourcingTests
       .CountAsync();
     
     Assert.Equal(0, count);
-    Assert.Equal(events.Count, deleted);
+    Assert.Equal(events.Length, deleted);
   }
 }

--- a/EventSourcing.Core.Tests/RecordStoreTests/DeleteAllSnapshotsAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/DeleteAllSnapshotsAsync.cs
@@ -12,7 +12,7 @@ public abstract partial class EventSourcingTests
         foreach (var _ in Enumerable.Range(0, 3))
         {
             var e = aggregate.Apply(new SnapshotEvent());
-            await store.AddEventsAsync(new List<Event> { e });
+            await store.AddEventsAsync(new [] { e });
             var snapshot = factory.CreateSnapshot(aggregate);
             await store.AddSnapshotAsync(snapshot);
         }
@@ -40,15 +40,15 @@ public abstract partial class EventSourcingTests
     public async Task RecordStore_DeleteAllSnapshotsAsync_Can_Only_Delete_Snapshots()
     {
         var aggregate = new EmptyAggregate();
-        var events = new List<Event>();
         var snapshot = new EmptySnapshot { AggregateId = aggregate.Id, AggregateType = nameof(EmptyAggregate)};
         var snapshot2 = new EmptySnapshot { AggregateId = aggregate.Id, AggregateType = nameof(EmptyAggregate), Index = 1};
         var projection = new EmptyProjection { AggregateId = aggregate.Id, AggregateType = nameof(EmptyAggregate), Hash = "RANDOM"};
 
-        for (var i = 0; i < 3; i++)
-            events.Add(aggregate.Apply(new EmptyEvent()));
-    
-    
+        var events = Enumerable
+            .Range(0, 3)
+            .Select(_ => aggregate.Apply(new EmptyEvent()))
+            .ToArray();
+
         await RecordStore.AddEventsAsync(events);
         await RecordStore.AddSnapshotAsync(snapshot);
         await RecordStore.AddSnapshotAsync(snapshot2);
@@ -85,7 +85,7 @@ public abstract partial class EventSourcingTests
         foreach (var _ in Enumerable.Range(0, 3))
         {
             var e = aggregate.Apply(new SnapshotEvent());
-            await store.AddEventsAsync(new List<Event> { e });
+            await store.AddEventsAsync(new [] { e });
             var snapshot = factory.CreateSnapshot(aggregate);
             await store.AddSnapshotAsync(snapshot);
         }

--- a/EventSourcing.Core.Tests/RecordStoreTests/DeleteSnapshotAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/DeleteSnapshotAsync.cs
@@ -7,7 +7,7 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = new SnapshotAggregate();
     var e = aggregate.Apply(new SnapshotEvent());
-    await RecordStore.AddEventsAsync(new List<Event> { e });
+    await RecordStore.AddEventsAsync(new [] { e });
 
     var factory = new SimpleSnapshotFactory();
     var snapshot = factory.CreateSnapshot(aggregate);

--- a/EventSourcing.Core.Tests/RecordStoreTests/GetEvents.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/GetEvents.cs
@@ -6,7 +6,7 @@ public abstract partial class EventSourcingTests
   public async Task RecordStore_GetEvents_Can_Query_Events_By_PartitionId()
   {
     var aggregate1 = new EmptyAggregate { PartitionId = Guid.NewGuid() };
-    var events1 = new List<Event>
+    var events1 = new []
     {
       aggregate1.Apply(new EmptyEvent()),
       aggregate1.Apply(new EmptyEvent()),
@@ -22,14 +22,14 @@ public abstract partial class EventSourcingTests
       .AsAsyncEnumerable()
       .CountAsync();
 
-    Assert.Equal(events1.Count, count);
+    Assert.Equal(events1.Length, count);
   }
   
   [Fact]
   public async Task RecordStore_GetEvents_Can_Query_Events_By_AggregateId()
   {
     var aggregate = new EmptyAggregate();
-    var events = new List<Event>
+    var events = new []
     {
       aggregate.Apply(new EmptyEvent()),
       aggregate.Apply(new EmptyEvent()),
@@ -45,21 +45,21 @@ public abstract partial class EventSourcingTests
       .AsAsyncEnumerable()
       .CountAsync();
 
-    Assert.Equal(events.Count, count);
+    Assert.Equal(events.Length, count);
   }
 
   [Fact]
   public async Task RecordStore_GetEvents_Can_Query_Events_By_AggregateVersion()
   {
     var aggregate = new EmptyAggregate();
-    var events = new List<Event>
+    var events = new []
     {
       aggregate.Apply(new EmptyEvent()),
       aggregate.Apply(new EmptyEvent())
     };
 
     var aggregate2 = new EmptyAggregate();
-    var events2 = new List<Event>
+    var events2 = new []
     {
       aggregate2.Apply(new EmptyEvent()),
       aggregate2.Apply(new EmptyEvent())
@@ -82,14 +82,14 @@ public abstract partial class EventSourcingTests
   public async Task RecordStore_GetEvents_Can_Query_Events_By_AggregateType()
   {
     var aggregate = new EmptyAggregate();
-    var events = new List<Event>
+    var events = new []
     {
       aggregate.Apply(new EmptyEvent()),
       aggregate.Apply(new EmptyEvent())
     };
 
     var aggregate2 = new SimpleAggregate();
-    var events2 = new List<Event>
+    var events2 = new []
     {
       aggregate2.Apply(new SimpleEvent()),
       aggregate2.Apply(new SimpleEvent())
@@ -142,7 +142,7 @@ public abstract partial class EventSourcingTests
       MockStringSet = new List<string> { "A", "B", "C", "C" }
     });
 
-    await RecordStore.AddEventsAsync(new List<Event> { e });
+    await RecordStore.AddEventsAsync(new [] { e });
 
     var result = (await RecordStore
         .GetEvents<MockAggregate>()
@@ -151,26 +151,7 @@ public abstract partial class EventSourcingTests
         .ToListAsync())
       .Cast<MockEvent>()
       .Single();
-
-    Assert.Equal(e.MockBoolean, result.MockBoolean);
-    Assert.Equal(e.MockString, result.MockString);
-    Assert.Equal(e.MockDecimal, result.MockDecimal);
-    Assert.Equal(e.MockDouble, result.MockDouble);
-    Assert.Equal(e.MockEnum, result.MockEnum);
-    Assert.Equal(e.MockFlagEnum, result.MockFlagEnum);
-    Assert.Equal(e.MockNestedRecord.MockBoolean, result.MockNestedRecord.MockBoolean);
-    Assert.Equal(e.MockNestedRecord.MockString, result.MockNestedRecord.MockString);
-    Assert.Equal(e.MockNestedRecord.MockDecimal, result.MockNestedRecord.MockDecimal);
-    Assert.Equal(e.MockNestedRecord.MockDouble, result.MockNestedRecord.MockDouble);
-    Assert.Equal(e.MockNestedRecordList.Single().MockBoolean, result.MockNestedRecordList.Single().MockBoolean);
-    Assert.Equal(e.MockNestedRecordList.Single().MockString, result.MockNestedRecordList.Single().MockString);
-    Assert.Equal(e.MockNestedRecordList.Single().MockDecimal, result.MockNestedRecordList.Single().MockDecimal);
-    Assert.Equal(e.MockNestedRecordList.Single().MockDouble, result.MockNestedRecordList.Single().MockDouble);
-    Assert.Equal(e.MockFloatList[0], result.MockFloatList[0]);
-    Assert.Equal(e.MockFloatList[1], result.MockFloatList[1]);
-    Assert.Equal(e.MockFloatList[2], result.MockFloatList[2]);
-    Assert.Contains(e.MockStringSet, x => x == "A");
-    Assert.Contains(e.MockStringSet, x => x == "B");
-    Assert.Contains(e.MockStringSet, x => x == "C");
+    
+    IMock.AssertEqual(e, result);
   }
 }

--- a/EventSourcing.Core.Tests/RecordStoreTests/GetProjections.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/GetProjections.cs
@@ -33,11 +33,11 @@ public abstract partial class EventSourcingTests
   [Fact]
   public async Task RecordStore_GetProjections_Can_Query_Aggregate_Projection_Hierarchy_After_Persisting()
   {
-    var PartitionId = Guid.NewGuid();
+    var partitionId = Guid.NewGuid();
 
-    await AggregateService.PersistAsync(Enumerable.Range(0, 3).Select(i =>
+    for (var i = 0; i < 3; i++)
     {
-      var aggregate = new HierarchyAggregate { PartitionId = PartitionId };
+      var aggregate = new HierarchyAggregate { PartitionId = partitionId };
       aggregate.Apply(i switch
         {
           0 => new HierarchyEvent("AA", "B", "C"),
@@ -45,11 +45,11 @@ public abstract partial class EventSourcingTests
           _ => new HierarchyEvent("A", "B", "CC")
         }
       );
-      return aggregate;
-    }));
-
+      await AggregateService.PersistAsync(aggregate);
+    }
+    
     var projections = await RecordStore.GetProjections<HierarchyProjection>()
-      .Where(x => x.PartitionId == PartitionId)
+      .Where(x => x.PartitionId == partitionId)
       .AsAsyncEnumerable()
       .ToListAsync();
 

--- a/EventSourcing.Core.Tests/RecordStoreTests/GetSnapshots.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/GetSnapshots.cs
@@ -7,7 +7,7 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = new SnapshotAggregate { PartitionId = Guid.NewGuid() };
     var e = aggregate.Apply(new SnapshotEvent());
-    await RecordStore.AddEventsAsync(new List<Event> { e });
+    await RecordStore.AddEventsAsync(new [] { e });
     
     var factory = new SimpleSnapshotFactory();
     await RecordStore.AddSnapshotAsync(factory.CreateSnapshot(aggregate));
@@ -26,7 +26,7 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = new SnapshotAggregate();
     var e = aggregate.Apply(new SnapshotEvent());
-    await RecordStore.AddEventsAsync(new List<Event> { e });
+    await RecordStore.AddEventsAsync(new [] { e });
 
     var factory = new SimpleSnapshotFactory();
     await RecordStore.AddSnapshotAsync(factory.CreateSnapshot(aggregate));
@@ -48,14 +48,14 @@ public abstract partial class EventSourcingTests
 
     var store = RecordStore;
 
-    await store.AddEventsAsync(new List<Event> { e1 });
+    await store.AddEventsAsync(new [] { e1 });
     
     var factory = new SimpleSnapshotFactory();
     
     var snapshot1 = factory.CreateSnapshot(aggregate);
     
     var e2 = aggregate.Apply(new SnapshotEvent());
-    await store.AddEventsAsync(new List<Event> { e2 });
+    await store.AddEventsAsync(new [] { e2 });
     
     var snapshot2 = factory.CreateSnapshot(aggregate);
 

--- a/EventSourcing.Core.Tests/RecordTransactionTests/AddSnapshot.cs
+++ b/EventSourcing.Core.Tests/RecordTransactionTests/AddSnapshot.cs
@@ -11,7 +11,7 @@ public abstract partial class EventSourcingTests
             { AggregateId = e.AggregateId, AggregateType = nameof(SnapshotAggregate), Index = 0, Counter = 10};
         
         await RecordStore.CreateTransaction()
-            .AddEvents(new Event[] { e })
+            .AddEvents(new List<Event<SnapshotAggregate>> { e })
             .AddSnapshot(s)
             .CommitAsync();
 

--- a/EventSourcing.Core.Tests/RecordTransactionTests/DeleteAllEvents.cs
+++ b/EventSourcing.Core.Tests/RecordTransactionTests/DeleteAllEvents.cs
@@ -8,7 +8,7 @@ public abstract partial class EventSourcingTests
         var aggregateId = Guid.NewGuid();
         
         var events = Enumerable.Range(0, 5)
-            .Select<int, Event>( i => new EmptyEvent
+            .Select<int, Event<EmptyAggregate>>(i => new EmptyEvent
             {
                 AggregateId = aggregateId,
                 AggregateType = nameof(EmptyAggregate),
@@ -46,7 +46,7 @@ public abstract partial class EventSourcingTests
             }).ToList();
 
         var transaction = RecordStore.CreateTransaction()
-            .AddEvents(new List<Event>
+            .AddEvents(new List<Event<EmptyAggregate>>
             {
                 new EmptyEvent
                 {

--- a/EventSourcing.Core/Aggregate.cs
+++ b/EventSourcing.Core/Aggregate.cs
@@ -31,7 +31,7 @@ public abstract class Aggregate : IHashable
   /// <remarks>
   /// All <see cref="Event"/>s added to this Aggregate will have set <c>Event.AggregateType = Aggregate.Type</c>
   /// </remarks>
-  public string Type { get; init; }
+  public string Type { get; }
   
   /// <summary>
   /// Unique Partition identifier. Defaults to <see cref="Guid"/>.<see cref="Guid.Empty"/>.
@@ -109,10 +109,10 @@ public abstract class Aggregate<TAggregate> : Aggregate where TAggregate : Aggre
 
   internal override void ClearUncommittedEvents() => UncommittedEvents.Clear();
 
-  internal async Task RehydrateAsync(Snapshot? snapshot, IAsyncEnumerable<Event<TAggregate>> events, CancellationToken cancellationToken = default)
+  internal async Task RehydrateAsync(Snapshot<TAggregate>? snapshot, IAsyncEnumerable<Event<TAggregate>> events, CancellationToken cancellationToken = default)
   {
-    if (snapshot != null) 
-      ValidateAndApply((Snapshot<TAggregate>) snapshot);
+    if (snapshot != null)
+      ValidateAndApply(snapshot);
     
     await foreach (var @event in events.WithCancellation(cancellationToken))
       ValidateAndApply(@event);
@@ -144,7 +144,7 @@ public abstract class Aggregate<TAggregate> : Aggregate where TAggregate : Aggre
       
       // Set Previous Event Reference to convince EF Core about Event consecutiveness
       // See https://github.com/Finaps/EventSourcing/issues/72
-      _previousEvent = UncommittedEvents.Cast<Event<TAggregate>>().LastOrDefault()
+      _previousEvent = UncommittedEvents.LastOrDefault()
     };
     
     ValidateAndApply(e);
@@ -197,25 +197,18 @@ public abstract class Aggregate<TAggregate> : Aggregate where TAggregate : Aggre
     return factory.CreateProjection(this) as TProjection;
   }
   
-  private void ValidateAndApply(Event e)
+  private void ValidateAndApply(Event<TAggregate> @event)
   {
-    if (e is not Event<TAggregate> @event)
-      throw new RecordValidationException($"{e} does not derive from {typeof(Event<TAggregate>)}");
-    
-    RecordValidation.ValidateEventForAggregate(this, e);
-    
+    RecordValidation.ValidateEventForAggregate(this, @event);
     Apply(@event);
     Version++;
   }
 
-  private void ValidateAndApply(Snapshot s)
+  private void ValidateAndApply(Snapshot<TAggregate> snapshot)
   {
-    if (s is not Snapshot<TAggregate> snapshot)
-      throw new RecordValidationException($"{s} does not derive from {typeof(Event<TAggregate>)}");
-    
-    RecordValidation.ValidateSnapshotForAggregate(this, s);
+    RecordValidation.ValidateSnapshotForAggregate(this, snapshot);
     Apply(snapshot);
-    Version = s.Index + 1;
+    Version = snapshot.Index + 1;
   }
 
   /// <inheritdoc />

--- a/EventSourcing.Core/Cache.cs
+++ b/EventSourcing.Core/Cache.cs
@@ -36,7 +36,7 @@ public static class Cache
       }
       else if (typeof(ISnapshotFactory).IsAssignableFrom(type))
       {
-        var factory = (ISnapshotFactory)Activator.CreateInstance(type)!;
+        var factory = (ISnapshotFactory) Activator.CreateInstance(type)!;
         SnapshotFactories.TryAdd(factory.AggregateType, new List<ISnapshotFactory>());
         SnapshotFactories[factory.AggregateType].Add(factory);
       }

--- a/EventSourcing.Core/Cache.cs
+++ b/EventSourcing.Core/Cache.cs
@@ -70,7 +70,7 @@ public static class Cache
   /// <typeparam name="TProjection"><see cref="Projection"/> type</typeparam>
   /// <returns><see cref="ProjectionFactory{TAggregate,TProjection}"/> if defined</returns>
   public static IProjectionFactory? GetProjectionFactory<TAggregate, TProjection>()
-    where TAggregate : Aggregate where TProjection : Projection => 
+    where TAggregate : Aggregate<TAggregate>, new() where TProjection : Projection => 
     ProjectionFactories.TryGetValue(typeof(TAggregate), out var factories)
       ? factories.TryGetValue(typeof(TProjection), out var factory) ? factory : null
       : null;

--- a/EventSourcing.Core/Cache.cs
+++ b/EventSourcing.Core/Cache.cs
@@ -52,16 +52,16 @@ public static class Cache
       ProjectionFactoryHashes[factory.AggregateType.Name] = IHashable.CombineHashes(
         factory.ComputeHash(), aggregateHashes[factory.AggregateType]);
   }
-  
+
   /// <summary>
   /// Get <see cref="SnapshotFactory{TAggregate,TSnapshot}"/>s for <see cref="Aggregate"/> type
   /// </summary>
-  /// <param name="aggregateType"><see cref="Aggregate"/> type</param>
+  /// <typeparam name="TAggregate"><see cref="Aggregate"/> type</typeparam>
   /// <returns><see cref="SnapshotFactory{TAggregate,TSnapshot}"/>s</returns>
-  public static IEnumerable<ISnapshotFactory> GetSnapshotFactories(Type aggregateType) =>
-    SnapshotFactories.TryGetValue(aggregateType, out var factories)
-      ? factories
-      : Array.Empty<ISnapshotFactory>();
+  public static IEnumerable<ISnapshotFactory<TAggregate>> GetSnapshotFactories<TAggregate>() where TAggregate : Aggregate<TAggregate>, new() =>
+    SnapshotFactories.TryGetValue(typeof(TAggregate), out var factories)
+      ? factories.Cast<ISnapshotFactory<TAggregate>>()
+      : Array.Empty<ISnapshotFactory<TAggregate>>();
 
   /// <summary>
   /// Get <see cref="ProjectionFactory{TAggregate,TProjection}"/> for <see cref="Aggregate"/> and <see cref="Projection"/>
@@ -78,10 +78,11 @@ public static class Cache
   /// <summary>
   /// Get <see cref="ProjectionFactory{TAggregate,TProjection}"/>s for <see cref="Aggregate"/> type
   /// </summary>
-  /// <param name="aggregateType"><see cref="Aggregate"/> type</param>
+  /// <typeparam name="TAggregate"><see cref="Aggregate"/> type</typeparam>
   /// <returns><see cref="ProjectionFactory{TAggregate,TProjection}"/>s</returns>
-  public static IEnumerable<IProjectionFactory> GetProjectionFactories(Type aggregateType) =>
-    ProjectionFactories.TryGetValue(aggregateType, out var factories)
+  public static IEnumerable<IProjectionFactory> GetProjectionFactories<TAggregate>()
+    where TAggregate : Aggregate<TAggregate>, new() => 
+    ProjectionFactories.TryGetValue(typeof(TAggregate), out var factories)
       ? factories.Values
       : Array.Empty<IProjectionFactory>();
 

--- a/EventSourcing.Core/EventSourcing.Core.csproj
+++ b/EventSourcing.Core/EventSourcing.Core.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <OutputType>Library</OutputType>
         <PackageId>Finaps.EventSourcing.Core</PackageId>
-        <Version>0.4.1</Version>
+        <Version>0.4.2</Version>
         <Authors>Niels Disveld, Bram Kraaijeveld</Authors>
         <Company>Finaps B.V.</Company>
         <RepositoryUrl>https://github.com/Finaps/EventSourcing</RepositoryUrl>

--- a/EventSourcing.Core/Records/Event.cs
+++ b/EventSourcing.Core/Records/Event.cs
@@ -19,7 +19,7 @@ public abstract record Event : Record
 }
 
 /// <inheritdoc />
-public record Event<TAggregate> : Event where TAggregate : Aggregate, new()
+public record Event<TAggregate> : Event where TAggregate : Aggregate<TAggregate>, new()
 {
   /// <inheritdoc />
   public Event() => AggregateType = typeof(TAggregate).Name;

--- a/EventSourcing.Core/Records/Record.cs
+++ b/EventSourcing.Core/Records/Record.cs
@@ -102,7 +102,7 @@ public abstract record Record
   /// <summary>
   /// Create new <see cref="Record"/>
   /// </summary>
-  public Record()
+  protected Record()
   {
     Type = GetType().Name;
     Timestamp = DateTimeOffset.UtcNow;

--- a/EventSourcing.Core/Records/Snapshot.cs
+++ b/EventSourcing.Core/Records/Snapshot.cs
@@ -29,7 +29,7 @@ public abstract record Snapshot : Record
 }
 
 /// <inheritdoc />
-public record Snapshot<TAggregate> : Snapshot where TAggregate : Aggregate, new()
+public record Snapshot<TAggregate> : Snapshot where TAggregate : Aggregate<TAggregate>, new()
 {
   /// <inheritdoc />
   public Snapshot() => AggregateType = typeof(TAggregate).Name;

--- a/EventSourcing.Core/Services/AggregateService/AggregateService.cs
+++ b/EventSourcing.Core/Services/AggregateService/AggregateService.cs
@@ -5,6 +5,9 @@ namespace Finaps.EventSourcing.Core;
 /// <inheritdoc />
 public class AggregateService : IAggregateService
 {
+  /// <summary>
+  /// <see cref="IRecordStore"/>
+  /// </summary>
   protected readonly IRecordStore Store;
   
   /// <summary>
@@ -54,7 +57,7 @@ public class AggregateService : IAggregateService
   /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
   /// <typeparam name="TAggregate"><see cref="Aggregate"/> type</typeparam>
   /// <returns><see cref="Snapshot"/> or <c>null</c></returns>
-  protected virtual async Task<Snapshot?> GetLatestSnapshotAsync<TAggregate>(
+  protected virtual async Task<Snapshot<TAggregate>?> GetLatestSnapshotAsync<TAggregate>(
     Guid partitionId, Guid aggregateId, DateTimeOffset date, CancellationToken cancellationToken = default)
     where TAggregate : Aggregate<TAggregate>, new()
   {
@@ -68,6 +71,7 @@ public class AggregateService : IAggregateService
       .Where(filter)
       .OrderByDescending(x => x.Index)
       .AsAsyncEnumerable()
+      .Cast<Snapshot<TAggregate>>()
       .FirstOrDefaultAsync(cancellationToken);
   }
 
@@ -77,7 +81,8 @@ public class AggregateService : IAggregateService
   /// <param name="partitionId"><see cref="Event"/>.<see cref="Record.PartitionId"/> to query</param>
   /// <param name="aggregateId"><see cref="Event"/>.<see cref="Record.AggregateId"/> to query</param>
   /// <param name="date">latest <see cref="DateTimeOffset"/> to query</param>
-  /// <param name="after"><see cref="Event"/>.<see cref="Event.Index"/> should be greater then (not equal to) <paramref name="after"/></param>
+  /// <param name="after"><see cref="Event"/>.<see cref="Event.Index"/> should be greater then (NOT equal to) <paramref name="after"/></param>
+  /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
   /// <typeparam name="TAggregate"><see cref="Aggregate"/> type</typeparam>
   /// <returns><see cref="IAsyncEnumerable{T}"/> of <see cref="Event"/></returns>
   protected virtual IAsyncEnumerable<Event<TAggregate>> GetEventStream<TAggregate>(

--- a/EventSourcing.Core/Services/AggregateService/AggregateTransaction.cs
+++ b/EventSourcing.Core/Services/AggregateService/AggregateTransaction.cs
@@ -3,6 +3,9 @@ namespace Finaps.EventSourcing.Core;
 /// <inheritdoc />
 public class AggregateTransaction : IAggregateTransaction
 {
+  /// <summary>
+  /// <see cref="IRecordTransaction"/>
+  /// </summary>
   protected readonly IRecordTransaction RecordTransaction;
   private readonly HashSet<Aggregate> _aggregates = new();
 
@@ -48,20 +51,23 @@ public class AggregateTransaction : IAggregateTransaction
   /// Add Events to RecordTransaction
   /// </summary>
   /// <param name="events"></param>
+  /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
   protected virtual Task AddEventsAsync<TAggregate>(List<Event<TAggregate>> events, CancellationToken cancellationToken = default)
     where TAggregate : Aggregate<TAggregate>, new() => Task.FromResult(RecordTransaction.AddEvents(events));
-  
+
   /// <summary>
   /// Add Snapshot to RecordTransaction
   /// </summary>
   /// <param name="snapshot"></param>
+  /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
   protected virtual Task AddSnapshotAsync<TAggregate>(Snapshot<TAggregate> snapshot, CancellationToken cancellationToken = default)
     where TAggregate : Aggregate<TAggregate>, new() => Task.FromResult(RecordTransaction.AddSnapshot(snapshot));
-  
+
   /// <summary>
   /// Add Projection to RecordTransaction
   /// </summary>
   /// <param name="projection"></param>
+  /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
   protected virtual Task UpsertProjectionAsync(Projection projection, CancellationToken cancellationToken = default) =>
     Task.FromResult(RecordTransaction.UpsertProjection(projection));
 

--- a/EventSourcing.Core/Services/AggregateService/IAggregateService.cs
+++ b/EventSourcing.Core/Services/AggregateService/IAggregateService.cs
@@ -14,7 +14,7 @@ public interface IAggregateService
   /// <typeparam name="TAggregate">Type of <see cref="Aggregate{TAggregate}"/></typeparam>
   /// <returns><see cref="Aggregate{TAggregate}"/> of type <c>TAggregate</c> or <c>null</c> when not found</returns>
   Task<TAggregate?> RehydrateAsync<TAggregate>(Guid partitionId, Guid aggregateId,
-    CancellationToken cancellationToken = default) where TAggregate : Aggregate, new();
+    CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new();
   
   /// <summary>
   /// Rehydrate <see cref="Aggregate{TAggregate}"/> up to a certain date.
@@ -26,7 +26,7 @@ public interface IAggregateService
   /// <typeparam name="TAggregate">Type of <see cref="Aggregate{TAggregate}"/></typeparam>
   /// <returns><see cref="Aggregate{TAggregate}"/> of type <c>TAggregate</c> as it was on <c>date</c> or null when not found</returns>
   Task<TAggregate?> RehydrateAsync<TAggregate>(Guid partitionId, Guid aggregateId, DateTimeOffset date,
-    CancellationToken cancellationToken = default) where TAggregate : Aggregate, new();
+    CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new();
 
   /// <summary>
   /// Persist <see cref="Aggregate{TAggregate}"/>
@@ -39,17 +39,7 @@ public interface IAggregateService
   /// <typeparam name="TAggregate">Type of <see cref="Aggregate{TAggregate}"/></typeparam>
   /// <returns>Persisted <see cref="Aggregate{TAggregate}"/></returns>
   Task PersistAsync<TAggregate>(TAggregate aggregate, CancellationToken cancellationToken = default)
-    where TAggregate : Aggregate, new();
-  
-  /// <summary>
-  /// Persist multiple <see cref="Aggregate{TAggregate}"/>s in a transaction
-  /// </summary>
-  /// <remarks>
-  /// This will store all uncommitted <see cref="Event"/>s of all <see cref="Aggregate{TAggregate}"/>s in an ACID <see cref="IAggregateTransaction"/>.
-  /// </remarks>
-  /// <param name="aggregates"><see cref="Aggregate{TAggregate}"/> to persist</param>
-  /// <param name="cancellationToken">Cancellation Token</param>
-  Task PersistAsync(IEnumerable<Aggregate> aggregates, CancellationToken cancellationToken = default);
+    where TAggregate : Aggregate<TAggregate>, new();
 
   /// <summary>
   /// Create ACID Aggregate Transaction
@@ -72,7 +62,7 @@ public interface IAggregateService
   /// <typeparam name="TAggregate">Type of <see cref="Aggregate{TAggregate}"/></typeparam>
   /// <returns><see cref="Aggregate{TAggregate}"/> of type <c>TAggregate</c> or null when not found</returns>
   public async Task<TAggregate?> RehydrateAsync<TAggregate>(Guid aggregateId,
-    CancellationToken cancellationToken = default) where TAggregate : Aggregate, new() =>
+    CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new() =>
     await RehydrateAsync<TAggregate>(Guid.Empty, aggregateId, cancellationToken);
 
   /// <summary>
@@ -84,7 +74,7 @@ public interface IAggregateService
   /// <typeparam name="TAggregate">Type of <see cref="Aggregate{TAggregate}"/></typeparam>
   /// <returns><see cref="Aggregate{TAggregate}"/> of type <c>TAggregate</c> as it was on <c>date</c> or null when not found</returns>
   public async Task<TAggregate?> RehydrateAsync<TAggregate>(Guid aggregateId, DateTimeOffset date,
-    CancellationToken cancellationToken = default) where TAggregate : Aggregate, new() =>
+    CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new() =>
     await RehydrateAsync<TAggregate>(Guid.Empty, aggregateId, date, cancellationToken);
 
   /// <summary>
@@ -97,7 +87,7 @@ public interface IAggregateService
   /// <typeparam name="TAggregate">Type of <see cref="Aggregate{TAggregate}"/></typeparam>
   /// <returns><see cref="Aggregate{TAggregate}"/> of type <c>TAggregate</c> or null when not found</returns>
   public async Task<TAggregate> RehydrateAndPersistAsync<TAggregate>(Guid partitionId, Guid aggregateId, Action<TAggregate> action,
-    CancellationToken cancellationToken = default) where TAggregate : Aggregate, new()
+    CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new()
   {
     var aggregate = await RehydrateAsync<TAggregate>(partitionId, aggregateId, cancellationToken);
 
@@ -118,7 +108,7 @@ public interface IAggregateService
   /// <typeparam name="TAggregate">Type of <see cref="Aggregate{TAggregate}"/></typeparam>
   /// <returns><see cref="Aggregate{TAggregate}"/> of type <c>TAggregate</c> or null when not found</returns>
   public async Task<TAggregate> RehydrateAndPersistAsync<TAggregate>(Guid aggregateId, Action<TAggregate> action,
-    CancellationToken cancellationToken = default) where TAggregate : Aggregate, new() =>
+    CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new() =>
     await RehydrateAndPersistAsync(Guid.Empty, aggregateId, action, cancellationToken);
   
   /// <summary>
@@ -130,7 +120,7 @@ public interface IAggregateService
   /// <typeparam name="TAggregate">Type of <see cref="Aggregate{TAggregate}"/></typeparam>
   /// <returns><see cref="Aggregate{TAggregate}"/> of type <c>TAggregate</c> or null when not found</returns>
   public async Task<TAggregate> RehydrateAndPersistAsync<TAggregate>(Guid partitionId, Guid aggregateId,
-    CancellationToken cancellationToken = default) where TAggregate : Aggregate, new() =>
+    CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new() =>
     await RehydrateAndPersistAsync<TAggregate>(partitionId, aggregateId, _ => {}, cancellationToken);
   
   /// <summary>
@@ -141,6 +131,6 @@ public interface IAggregateService
   /// <typeparam name="TAggregate">Type of <see cref="Aggregate{TAggregate}"/></typeparam>
   /// <returns><see cref="Aggregate{TAggregate}"/> of type <c>TAggregate</c> or null when not found</returns>
   public async Task<TAggregate> RehydrateAndPersistAsync<TAggregate>(Guid aggregateId,
-    CancellationToken cancellationToken = default) where TAggregate : Aggregate, new() =>
+    CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new() =>
     await RehydrateAndPersistAsync<TAggregate>(Guid.Empty, aggregateId, _ => {}, cancellationToken);
 }

--- a/EventSourcing.Core/Services/AggregateService/IAggregateTransaction.cs
+++ b/EventSourcing.Core/Services/AggregateService/IAggregateTransaction.cs
@@ -12,8 +12,10 @@ public interface IAggregateTransaction
   /// When all <see cref="Aggregate{TAggregate}"/>s have been added, call <see cref="CommitAsync"/> to commit them
   /// </remarks>
   /// <param name="aggregate"><see cref="Aggregate{TAggregate}"/></param>
+  /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
   /// <returns><see cref="IAggregateTransaction"/></returns>
-  Task<IAggregateTransaction> AddAggregateAsync(Aggregate aggregate);
+  Task<IAggregateTransaction> AddAggregateAsync<TAggregate>(TAggregate aggregate, CancellationToken cancellationToken = default)
+    where TAggregate : Aggregate<TAggregate>, new();
 
   /// <summary>
   /// Commit <see cref="Aggregate{TAggregate}"/>s to the <see cref="IRecordStore"/> in an ACID transaction.

--- a/EventSourcing.Core/Services/ProjectionService/IProjectionUpdateService.cs
+++ b/EventSourcing.Core/Services/ProjectionService/IProjectionUpdateService.cs
@@ -27,5 +27,5 @@ public interface IProjectionUpdateService
   /// <typeparam name="TProjection"><see cref="Projection"/> type</typeparam>
   /// <param name="cancellationToken">Cancellation token</param>
   Task UpdateAllProjectionsAsync<TAggregate, TProjection>(CancellationToken cancellationToken = default)
-    where TAggregate : Aggregate, new() where TProjection : Projection;
+    where TAggregate : Aggregate<TAggregate>, new() where TProjection : Projection;
 }

--- a/EventSourcing.Core/Services/ProjectionService/ProjectionFactory.cs
+++ b/EventSourcing.Core/Services/ProjectionService/ProjectionFactory.cs
@@ -7,7 +7,9 @@ namespace Finaps.EventSourcing.Core;
 /// </summary>
 /// <typeparam name="TAggregate"><see cref="Aggregate{TAggregate}"/> type</typeparam>
 /// <typeparam name="TProjection"><see cref="Projection"/> type</typeparam>
-public abstract class ProjectionFactory<TAggregate, TProjection> : IProjectionFactory where TAggregate : Aggregate where TProjection : Projection
+public abstract class ProjectionFactory<TAggregate, TProjection> : IProjectionFactory
+  where TAggregate : Aggregate<TAggregate>, new()
+  where TProjection : Projection
 {
   /// <inheritdoc />
   public Type AggregateType => typeof(TAggregate);

--- a/EventSourcing.Core/Services/ProjectionService/ProjectionUpdateService.cs
+++ b/EventSourcing.Core/Services/ProjectionService/ProjectionUpdateService.cs
@@ -24,7 +24,7 @@ public class ProjectionUpdateService : IProjectionUpdateService
   /// <typeparam name="TAggregate"><see cref="Aggregate{TAggregate}"/> type</typeparam>
   /// <typeparam name="TProjection"><see cref="Projection"/> type</typeparam>
   public async Task UpdateAllProjectionsAsync<TAggregate, TProjection>(CancellationToken cancellationToken = default)
-    where TAggregate : Aggregate, new() where TProjection : Projection
+    where TAggregate : Aggregate<TAggregate>, new() where TProjection : Projection
   {
     var factory = Cache.GetProjectionFactory<TAggregate, TProjection>();
 

--- a/EventSourcing.Core/Services/RecordStore/IRecordStore.cs
+++ b/EventSourcing.Core/Services/RecordStore/IRecordStore.cs
@@ -14,7 +14,7 @@ public interface IRecordStore
   /// and use <c>System.Linq.Async</c>'s extension methods to get the results of your query
   /// </remarks>
   /// <seealso cref="Event"/>
-  IQueryable<Event> GetEvents<TAggregate>() where TAggregate : Aggregate, new();
+  IQueryable<Event> GetEvents<TAggregate>() where TAggregate : Aggregate<TAggregate>, new();
   
   /// <summary>
   /// Queryable and AsyncEnumerable Collection of <see cref="Snapshot"/>s
@@ -24,7 +24,7 @@ public interface IRecordStore
   /// and use <c>System.Linq.Async</c>'s extension methods to get the results of your query
   /// </remarks>
   /// <seealso cref="Snapshot"/>
-  IQueryable<Snapshot> GetSnapshots<TAggregate>() where TAggregate : Aggregate, new();
+  IQueryable<Snapshot> GetSnapshots<TAggregate>() where TAggregate : Aggregate<TAggregate>, new();
 
   /// <summary>
   /// Queryable and AsyncEnumerable Collection of <see cref="Projection"/>s
@@ -57,14 +57,16 @@ public interface IRecordStore
   /// <exception cref="ArgumentException">Thrown when trying to add <see cref="Event"/>s with <see cref="Guid.Empty"/> <see cref="Record.AggregateId"/></exception>
   /// <exception cref="ArgumentException">Thrown when trying to add <see cref="Event"/>s with nonconsecutive <see cref="Event.Index"/></exception>
   /// <exception cref="RecordStoreException">Thrown when conflicts occur when storing <see cref="Event"/>s</exception>
-  Task AddEventsAsync(IList<Event> events, CancellationToken cancellationToken = default);
+  Task AddEventsAsync<TAggregate>(IReadOnlyCollection<Event<TAggregate>> events, CancellationToken cancellationToken = default)
+    where TAggregate : Aggregate<TAggregate>, new();
   
   /// <summary>
   /// Store <see cref="Snapshot"/> to the <see cref="IRecordStore"/>
   /// </summary>
   /// <param name="snapshot"><see cref="Snapshot"/> to add</param>
   /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
-  Task AddSnapshotAsync(Snapshot snapshot, CancellationToken cancellationToken = default);
+  Task AddSnapshotAsync<TAggregate>(Snapshot<TAggregate> snapshot, CancellationToken cancellationToken = default)
+    where TAggregate : Aggregate<TAggregate>, new();
   
   /// <summary>
   /// Store <see cref="Projection"/> to the <see cref="IRecordStore"/>
@@ -80,7 +82,7 @@ public interface IRecordStore
   /// <param name="aggregateId">Aggregate Id</param>
   /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
   /// <exception cref="RecordStoreException">Thrown when conflicts occur when deleting <see cref="Event"/>s</exception>
-  Task<int> DeleteAllEventsAsync<TAggregate>(Guid partitionId, Guid aggregateId, CancellationToken cancellationToken = default) where TAggregate : Aggregate, new();
+  Task<int> DeleteAllEventsAsync<TAggregate>(Guid partitionId, Guid aggregateId, CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new();
 
   /// <summary>
   /// Delete <see cref="Snapshot"/>s for an <see cref="Aggregate{TAggregate}"/> from the <see cref="IRecordStore"/>
@@ -89,7 +91,7 @@ public interface IRecordStore
   /// <param name="aggregateId">Aggregate Id</param>
   /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
   /// <exception cref="RecordStoreException">Thrown when conflicts occur when deleting <see cref="Snapshot"/>s</exception>
-  Task<int> DeleteAllSnapshotsAsync<TAggregate>(Guid partitionId, Guid aggregateId, CancellationToken cancellationToken = default) where TAggregate : Aggregate, new();
+  Task<int> DeleteAllSnapshotsAsync<TAggregate>(Guid partitionId, Guid aggregateId, CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new();
 
   /// <summary>
   /// Delete <see cref="Snapshot"/>s for an <see cref="Aggregate{TAggregate}"/> from the <see cref="IRecordStore"/>
@@ -99,7 +101,7 @@ public interface IRecordStore
   /// <param name="index"><see cref="Snapshot"/> <see cref="Snapshot.Index"/></param>
   /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
   /// <exception cref="RecordStoreException">Thrown when conflicts occur when deleting <see cref="Snapshot"/>s</exception>
-  Task DeleteSnapshotAsync<TAggregate>(Guid partitionId, Guid aggregateId, long index, CancellationToken cancellationToken = default) where TAggregate : Aggregate, new();
+  Task DeleteSnapshotAsync<TAggregate>(Guid partitionId, Guid aggregateId, long index, CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new();
 
   /// <summary>
   /// Delete <see cref="Projection"/>s for an <see cref="Aggregate{TAggregate}"/> from the <see cref="IRecordStore"/>
@@ -114,7 +116,7 @@ public interface IRecordStore
   /// Delete all <see cref="Event"/>s, <see cref="Snapshot"/>s and <see cref="Projection"/>s for an <see cref="Aggregate{TAggregate}"/>
   /// </summary>
   /// <returns>Number of items deleted from <see cref="IRecordStore"/></returns>
-  Task<int> DeleteAggregateAsync<TAggregate>(Guid partitionId, Guid aggregateId, CancellationToken cancellationToken = default) where TAggregate : Aggregate, new();
+  Task<int> DeleteAggregateAsync<TAggregate>(Guid partitionId, Guid aggregateId, CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new();
 
   /// <summary>
   /// Create Record Transaction
@@ -140,7 +142,7 @@ public interface IRecordStore
   /// </summary>
   /// <param name="aggregateId">Aggregate Id</param>
   /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
-  async Task<int> DeleteAllEventsAsync<TAggregate>(Guid aggregateId, CancellationToken cancellationToken = default) where TAggregate : Aggregate, new() =>
+  async Task<int> DeleteAllEventsAsync<TAggregate>(Guid aggregateId, CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new() =>
     await DeleteAllEventsAsync<TAggregate>(Guid.Empty, aggregateId, cancellationToken);
 
   /// <summary>
@@ -148,7 +150,7 @@ public interface IRecordStore
   /// </summary>
   /// <param name="aggregateId">Aggregate Id</param>
   /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
-  async Task<int> DeleteAllSnapshotsAsync<TAggregate>(Guid aggregateId, CancellationToken cancellationToken = default) where TAggregate : Aggregate, new() =>
+  async Task<int> DeleteAllSnapshotsAsync<TAggregate>(Guid aggregateId, CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new() =>
     await DeleteAllSnapshotsAsync<TAggregate>(Guid.Empty, aggregateId, cancellationToken);
 
   /// <summary>
@@ -157,7 +159,7 @@ public interface IRecordStore
   /// <param name="aggregateId">Aggregate Id</param>
   /// <param name="index"><see cref="Snapshot"/> <see cref="Snapshot.Index"/></param>
   /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
-  async Task DeleteSnapshotAsync<TAggregate>(Guid aggregateId, long index, CancellationToken cancellationToken = default) where TAggregate : Aggregate, new() =>
+  async Task DeleteSnapshotAsync<TAggregate>(Guid aggregateId, long index, CancellationToken cancellationToken = default) where TAggregate : Aggregate<TAggregate>, new() =>
     await DeleteSnapshotAsync<TAggregate>(Guid.Empty, aggregateId, index, cancellationToken);
 
   /// <summary>

--- a/EventSourcing.Core/Services/RecordStore/IRecordTransaction.cs
+++ b/EventSourcing.Core/Services/RecordStore/IRecordTransaction.cs
@@ -21,14 +21,14 @@ public interface IRecordTransaction
   /// <exception cref="ArgumentException">Thrown when trying to add <see cref="Event"/>s with <see cref="Guid.Empty"/> <see cref="Record.AggregateId"/></exception>
   /// <exception cref="ArgumentException">Thrown when trying to add <see cref="Event"/>s with nonconsecutive <see cref="Event.Index"/>s</exception>
   /// <returns>This <see cref="IRecordTransaction"/></returns>
-  IRecordTransaction AddEvents(IList<Event> events);
+  IRecordTransaction AddEvents<TAggregate>(IReadOnlyCollection<Event<TAggregate>> events) where TAggregate : Aggregate<TAggregate>, new();
   
   /// <summary>
   /// Add <see cref="Snapshot"/>
   /// </summary>
   /// <param name="snapshot"><see cref="Snapshot"/> to add</param>
   /// <returns>This <see cref="IRecordTransaction"/></returns>
-  IRecordTransaction AddSnapshot(Snapshot snapshot);
+  IRecordTransaction AddSnapshot<TAggregate>(Snapshot<TAggregate> snapshot) where TAggregate : Aggregate<TAggregate>, new();
   
   /// <summary>
   /// Upsert <see cref="Projection"/>
@@ -46,7 +46,7 @@ public interface IRecordTransaction
   /// For a more convenient method, refer to the async delete methods in <see cref="IRecordStore"/>
   /// </remarks>
   /// <returns></returns>
-  IRecordTransaction DeleteAllEvents<TAggregate>(Guid aggregateId, long index) where TAggregate : Aggregate, new();
+  IRecordTransaction DeleteAllEvents<TAggregate>(Guid aggregateId, long index) where TAggregate : Aggregate<TAggregate>, new();
   
   /// <summary>
   /// Delete <see cref="Snapshot"/> at a particular <see cref="Snapshot.Index"/> 
@@ -54,7 +54,7 @@ public interface IRecordTransaction
   /// <param name="aggregateId"><see cref="Aggregate{TAggregate}"/>.<see cref="Aggregate.Id"/></param>
   /// <param name="index"><see cref="Snapshot"/>.<see cref="Snapshot.Index"/> to delete</param>
   /// <returns></returns>
-  IRecordTransaction DeleteSnapshot<TAggregate>(Guid aggregateId, long index) where TAggregate : Aggregate, new();
+  IRecordTransaction DeleteSnapshot<TAggregate>(Guid aggregateId, long index) where TAggregate : Aggregate<TAggregate>, new();
   
   /// <summary>
   /// Delete <see cref="Projection"/>

--- a/EventSourcing.Core/Services/SnapshotFactory/ISnapshotFactory.cs
+++ b/EventSourcing.Core/Services/SnapshotFactory/ISnapshotFactory.cs
@@ -1,8 +1,5 @@
 namespace Finaps.EventSourcing.Core;
 
-/// <summary>
-/// Create <see cref="Snapshot"/> for <see cref="Aggregate{TAggregate}"/>
-/// </summary>
 public interface ISnapshotFactory
 {
   /// <summary>
@@ -19,18 +16,25 @@ public interface ISnapshotFactory
   /// The interval, in number of <see cref="Event"/>s, for which a <see cref="Snapshot"/> should be created.
   /// </summary>
   public long SnapshotInterval { get; }
-  
+}
+
+/// <summary>
+/// Create <see cref="Snapshot"/> for <see cref="Aggregate{TAggregate}"/>
+/// </summary>
+public interface ISnapshotFactory<TAggregate> : ISnapshotFactory
+  where TAggregate : Aggregate<TAggregate>, new()
+{
   /// <summary>
   /// Calculates if the <see cref="SnapshotInterval"/> has been exceeded (and a <see cref="Snapshot"/> thus has to be created)
   /// </summary>
   /// <param name="aggregate">The <see cref="Aggregate{TAggregate}"/> to check</param>
   /// <returns>True if <see cref="SnapshotInterval"/> has been exceeded</returns>
-  bool IsSnapshotIntervalExceeded(Aggregate aggregate);
+  bool IsSnapshotIntervalExceeded(TAggregate aggregate);
   
   /// <summary>
   /// Create <see cref="Snapshot"/> defined for a particular <see cref="Aggregate{TAggregate}"/>
   /// </summary>
   /// <param name="aggregate">Source <see cref="Aggregate{TAggregate}"/></param>
   /// <returns>Resulting <see cref="Snapshot"/>s of <see cref="Aggregate{TAggregate}"/></returns>
-  Snapshot CreateSnapshot(Aggregate aggregate);
+  Snapshot<TAggregate> CreateSnapshot(Aggregate aggregate);
 }

--- a/EventSourcing.Core/Services/SnapshotFactory/ISnapshotFactory.cs
+++ b/EventSourcing.Core/Services/SnapshotFactory/ISnapshotFactory.cs
@@ -1,5 +1,8 @@
 namespace Finaps.EventSourcing.Core;
 
+/// <summary>
+/// Create <see cref="Snapshot"/> for <see cref="Aggregate{TAggregate}"/>
+/// </summary>
 public interface ISnapshotFactory
 {
   /// <summary>
@@ -18,17 +21,14 @@ public interface ISnapshotFactory
   public long SnapshotInterval { get; }
 }
 
-/// <summary>
-/// Create <see cref="Snapshot"/> for <see cref="Aggregate{TAggregate}"/>
-/// </summary>
-public interface ISnapshotFactory<TAggregate> : ISnapshotFactory
-  where TAggregate : Aggregate<TAggregate>, new()
+/// <inheritdoc />
+public interface ISnapshotFactory<TAggregate> : ISnapshotFactory where TAggregate : Aggregate<TAggregate>, new()
 {
   /// <summary>
-  /// Calculates if the <see cref="SnapshotInterval"/> has been exceeded (and a <see cref="Snapshot"/> thus has to be created)
+  /// Calculates if the <see cref="ISnapshotFactory.SnapshotInterval"/> has been exceeded (and a <see cref="Snapshot"/> thus has to be created)
   /// </summary>
   /// <param name="aggregate">The <see cref="Aggregate{TAggregate}"/> to check</param>
-  /// <returns>True if <see cref="SnapshotInterval"/> has been exceeded</returns>
+  /// <returns>True if <see cref="ISnapshotFactory.SnapshotInterval"/> has been exceeded</returns>
   bool IsSnapshotIntervalExceeded(TAggregate aggregate);
   
   /// <summary>
@@ -36,5 +36,5 @@ public interface ISnapshotFactory<TAggregate> : ISnapshotFactory
   /// </summary>
   /// <param name="aggregate">Source <see cref="Aggregate{TAggregate}"/></param>
   /// <returns>Resulting <see cref="Snapshot"/>s of <see cref="Aggregate{TAggregate}"/></returns>
-  Snapshot<TAggregate> CreateSnapshot(Aggregate aggregate);
+  Snapshot<TAggregate> CreateSnapshot(Aggregate<TAggregate> aggregate);
 }

--- a/EventSourcing.Core/Services/SnapshotFactory/SnapshotFactory.cs
+++ b/EventSourcing.Core/Services/SnapshotFactory/SnapshotFactory.cs
@@ -5,8 +5,9 @@ namespace Finaps.EventSourcing.Core;
 /// </summary>
 /// <typeparam name="TAggregate"><see cref="Aggregate{TAggregate}"/> type</typeparam>
 /// <typeparam name="TSnapshot"><see cref="Projection"/> type</typeparam>
-public abstract class SnapshotFactory<TAggregate, TSnapshot> : ISnapshotFactory
-  where TAggregate : Aggregate where TSnapshot : Snapshot
+public abstract class SnapshotFactory<TAggregate, TSnapshot> : ISnapshotFactory<TAggregate>
+  where TAggregate : Aggregate<TAggregate>, new()
+  where TSnapshot : Snapshot<TAggregate>
 {
   /// <inheritdoc />
   public Type AggregateType => typeof(TAggregate);
@@ -18,13 +19,13 @@ public abstract class SnapshotFactory<TAggregate, TSnapshot> : ISnapshotFactory
   public abstract long SnapshotInterval { get; }
   
   /// <inheritdoc />
-  public bool IsSnapshotIntervalExceeded(Aggregate aggregate) =>
+  public bool IsSnapshotIntervalExceeded(TAggregate aggregate) =>
     SnapshotInterval != 0 && aggregate.UncommittedEvents.Any() && 
     aggregate.UncommittedEvents.First().Index / SnapshotInterval != 
     (aggregate.UncommittedEvents.Last().Index + 1) / SnapshotInterval;
 
   /// <inheritdoc />
-  public Snapshot CreateSnapshot(Aggregate aggregate)
+  public Snapshot<TAggregate> CreateSnapshot(Aggregate aggregate)
   {
     if (aggregate.Version == 0)
       throw new InvalidOperationException(

--- a/EventSourcing.Core/Services/SnapshotFactory/SnapshotFactory.cs
+++ b/EventSourcing.Core/Services/SnapshotFactory/SnapshotFactory.cs
@@ -25,7 +25,7 @@ public abstract class SnapshotFactory<TAggregate, TSnapshot> : ISnapshotFactory<
     (aggregate.UncommittedEvents.Last().Index + 1) / SnapshotInterval;
 
   /// <inheritdoc />
-  public Snapshot<TAggregate> CreateSnapshot(Aggregate aggregate)
+  public Snapshot<TAggregate> CreateSnapshot(Aggregate<TAggregate> aggregate)
   {
     if (aggregate.Version == 0)
       throw new InvalidOperationException(

--- a/EventSourcing.Core/Services/Validation/RecordValidation.cs
+++ b/EventSourcing.Core/Services/Validation/RecordValidation.cs
@@ -42,7 +42,8 @@ public static class RecordValidation
   /// </summary>
   /// <param name="partitionId">Partition Id this sequence is expected to be in</param>
   /// <param name="events"><see cref="Event"/>s to validate</param>
-  public static void ValidateEventSequence(Guid partitionId, IList<Event> events)
+  public static void ValidateEventSequence<TAggregate>(Guid partitionId, IReadOnlyCollection<Event<TAggregate>> events)
+    where TAggregate : Aggregate<TAggregate>, new()
   {
     if (events == null) throw new ArgumentNullException(nameof(events));
 

--- a/EventSourcing.Cosmos.Tests/CosmosEventSourcingTests.cs
+++ b/EventSourcing.Cosmos.Tests/CosmosEventSourcingTests.cs
@@ -79,7 +79,7 @@ public partial class CosmosEventSourcingTests : EventSourcingTests
     }));
 
     var exception = await Assert.ThrowsAsync<RecordStoreException>(async () =>
-      await store.AddEventsAsync(new List<Event> { new EmptyAggregate().Apply(new EmptyEvent()) }));
+      await store.AddEventsAsync(new [] { new EmptyAggregate().Apply(new EmptyEvent()) }));
     Assert.Contains("401", exception.Message);
   }
     
@@ -94,7 +94,7 @@ public partial class CosmosEventSourcingTests : EventSourcingTests
     }));
 
     var exception = await Assert.ThrowsAsync<RecordStoreException>(async () =>
-      await store.AddEventsAsync(new List<Event> { new EmptyAggregate().Apply(new EmptyEvent()) }));
+      await store.AddEventsAsync(new [] { new EmptyAggregate().Apply(new EmptyEvent()) }));
     Assert.Contains("404", exception.Message);
   }
     
@@ -109,7 +109,7 @@ public partial class CosmosEventSourcingTests : EventSourcingTests
     }));
 
     var exception = await Assert.ThrowsAsync<RecordStoreException>(async () =>
-      await store.AddEventsAsync(new List<Event> { new EmptyAggregate().Apply(new EmptyEvent()) }));
+      await store.AddEventsAsync(new [] { new EmptyAggregate().Apply(new EmptyEvent()) }));
     Assert.Contains("404", exception.Message);
   }
     

--- a/EventSourcing.Cosmos.Tests/RecordAttributeTests.cs
+++ b/EventSourcing.Cosmos.Tests/RecordAttributeTests.cs
@@ -17,7 +17,7 @@ public partial class CosmosEventSourcingTests
     var e = new EmptyAggregate().Apply(new AttributeEvent("something"));
     var recordType = e.GetType().GetCustomAttribute<RecordTypeAttribute>()!.Type;
 
-    await RecordStore.AddEventsAsync(new List<Event> { e });
+    await RecordStore.AddEventsAsync(new [] { e });
     var result = await RecordStore
       .GetEvents<EmptyAggregate>()
       .Where(x => x.Type == recordType && x.AggregateId == e.AggregateId)
@@ -33,7 +33,7 @@ public partial class CosmosEventSourcingTests
     var e = new EmptyAggregate().Apply(new AttributeEvent("something"));
     var recordType = e.GetType().GetCustomAttribute<RecordTypeAttribute>()!.Type;
 
-    await RecordStore.AddEventsAsync(new List<Event> { e });
+    await RecordStore.AddEventsAsync(new [] { e });
 
     var result = await RecordStore
       .GetEvents<EmptyAggregate>()

--- a/EventSourcing.Cosmos/CosmosRecordTransaction.cs
+++ b/EventSourcing.Cosmos/CosmosRecordTransaction.cs
@@ -40,7 +40,8 @@ public class CosmosRecordTransaction : IRecordTransaction
   }
 
   /// <inheritdoc />
-  public IRecordTransaction AddEvents(IList<Event> events)
+  public IRecordTransaction AddEvents<TAggregate>(IReadOnlyCollection<Event<TAggregate>> events)
+    where TAggregate : Aggregate<TAggregate>, new()
   {
     RecordValidation.ValidateEventSequence(PartitionId, events);
 
@@ -73,7 +74,8 @@ public class CosmosRecordTransaction : IRecordTransaction
   }
 
   /// <inheritdoc />
-  public IRecordTransaction AddSnapshot(Snapshot snapshot)
+  public IRecordTransaction AddSnapshot<TAggregate>(Snapshot<TAggregate> snapshot)
+    where TAggregate : Aggregate<TAggregate>, new()
   {
     RecordValidation.ValidateSnapshot(PartitionId, snapshot);
     _batch.CreateItem(snapshot, CosmosRecordStore.BatchItemRequestOptions);
@@ -92,7 +94,8 @@ public class CosmosRecordTransaction : IRecordTransaction
   }
 
   /// <inheritdoc />
-  public IRecordTransaction DeleteAllEvents<TAggregate>(Guid aggregateId, long index) where TAggregate : Aggregate, new()
+  public IRecordTransaction DeleteAllEvents<TAggregate>(Guid aggregateId, long index)
+    where TAggregate : Aggregate<TAggregate>, new()
   {
     var reservation = new CheckEvent
     {
@@ -122,7 +125,8 @@ public class CosmosRecordTransaction : IRecordTransaction
   }
 
   /// <inheritdoc />
-  public IRecordTransaction DeleteSnapshot<TAggregate>(Guid aggregateId, long index) where TAggregate : Aggregate, new()
+  public IRecordTransaction DeleteSnapshot<TAggregate>(Guid aggregateId, long index)
+    where TAggregate : Aggregate<TAggregate>, new()
   {
     var snapshot = new CheckSnapshot { PartitionId = PartitionId, AggregateId = aggregateId, Index = index };
     _batch.DeleteItem(snapshot.id, CosmosRecordStore.BatchItemRequestOptions);

--- a/EventSourcing.Cosmos/EventSourcing.Cosmos.csproj
+++ b/EventSourcing.Cosmos/EventSourcing.Cosmos.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <OutputType>Library</OutputType>
         <PackageId>Finaps.EventSourcing.Cosmos</PackageId>
-        <Version>0.4.1</Version>
+        <Version>0.4.2</Version>
         <Authors>Niels Disveld, Bram Kraaijeveld</Authors>
         <Company>Finaps B.V.</Company>
         <RepositoryUrl>https://github.com/Finaps/EventSourcing</RepositoryUrl>

--- a/EventSourcing.EF/EventSourcing.EF.csproj
+++ b/EventSourcing.EF/EventSourcing.EF.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <OutputType>Library</OutputType>
         <PackageId>Finaps.EventSourcing.EF</PackageId>
-        <Version>0.4.1</Version>
+        <Version>0.4.2</Version>
         <Authors>Niels Disveld, Bram Kraaijeveld</Authors>
         <Company>Finaps B.V.</Company>
         <RepositoryUrl>https://github.com/Finaps/EventSourcing</RepositoryUrl>

--- a/EventSourcing.EF/ModelBuilderExtensions.cs
+++ b/EventSourcing.EF/ModelBuilderExtensions.cs
@@ -22,7 +22,7 @@ public static class ModelBuilderExtensions
   /// <returns><see cref="ReferenceCollectionBuilder"/> such that the reference can be further configured</returns>
   public static ReferenceCollectionBuilder<Event<TAggregate>, TEvent> AggregateReference<TEvent, TAggregate>(
     this ModelBuilder builder, Expression<Func<TEvent, Guid?>> navigation) 
-    where TEvent : Event where TAggregate : Aggregate, new()
+    where TEvent : Event where TAggregate : Aggregate<TAggregate>, new()
   {
     var foreignAggregateId = navigation.GetMemberAccess().GetSimpleMemberName();
     var foreignKeyName = $"FK_{typeof(TEvent).Name}_{foreignAggregateId}";

--- a/EventSourcing.Example/Controllers/ProductsController.cs
+++ b/EventSourcing.Example/Controllers/ProductsController.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Finaps.EventSourcing.Example.Domain.Products;
 using Microsoft.AspNetCore.Mvc;
 
@@ -19,18 +20,18 @@ public class ProductsController : Controller
     }
 
     [HttpPost]
-    public async Task<ActionResult<Product>> CreateProduct([FromBody] CreateProduct request)
+    public async Task<ActionResult<Product>> CreateProduct([FromBody] CreateProduct request, CancellationToken cancellationToken = default)
     {
         var product = new Product();
         product.Create(request.Name, request.Quantity);
-        await _aggregateService.PersistAsync(product);
+        await _aggregateService.PersistAsync(product, cancellationToken);
         return product;
     }
     
     [HttpGet("{id:Guid}")]
-    public async Task<ActionResult<Product>> GetProduct([FromRoute] Guid id)
+    public async Task<ActionResult<Product>> GetProduct([FromRoute] Guid id, CancellationToken cancellationToken = default)
     {
-        var product = await _aggregateService.RehydrateAsync<Product>(id);
+        var product = await _aggregateService.RehydrateAsync<Product>(id, cancellationToken);
         if(product == null)
             return BadRequest($"Product with id {id} not found");
         
@@ -38,9 +39,9 @@ public class ProductsController : Controller
     }
     
     [HttpPost("{id:Guid}/addStock")]
-    public async Task<ActionResult<Product>> AddStock([FromRoute] Guid id, [FromBody] AddStock request)
+    public async Task<ActionResult<Product>> AddStock([FromRoute] Guid id, [FromBody] AddStock request, CancellationToken cancellationToken = default)
     {
         return await _aggregateService.RehydrateAndPersistAsync<Product>(id, 
-            product => product.AddStock(request.Quantity));
+            product => product.AddStock(request.Quantity), cancellationToken);
     }
 }


### PR DESCRIPTION
Changes:
- RecordStore/RecordTransaction.ApplyEvents(Async) now accepts IReadOnlyCollection<Events\<TAggregate\>>
- Updated TAggregate generic type constraints -> TAggregate : Aggregate\<TAggregate\>, new();
- Remove IAggregateService.PersistAsync with multiple Aggregates to allow generics to be tighter
- Make all methods in AggregateService/AggregateTransaction virtual; Add Cancellation tokens
- Add -warnaserror build flag during tests to prevent PR's with warnings from being merged