### PR TITLE
Allow Custom DbContextTransactions in Finaps.EventSourcing.EF

### DIFF
--- a/EventSourcing.Core.Tests/AggregateServiceTests/PersistAsync.cs
+++ b/EventSourcing.Core.Tests/AggregateServiceTests/PersistAsync.cs
@@ -8,9 +8,9 @@ public abstract partial class EventSourcingTests
     var aggregate = new SimpleAggregate();
     aggregate.Apply(new SimpleEvent());
 
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var result = await RecordStore
+    var result = await GetRecordStore()
       .GetEvents<SimpleAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -30,9 +30,9 @@ public abstract partial class EventSourcingTests
       aggregate.Apply(new SimpleEvent())
     };
 
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var eventCount = await RecordStore
+    var eventCount = await GetRecordStore()
       .GetEvents<SimpleAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -51,15 +51,15 @@ public abstract partial class EventSourcingTests
     foreach (var _ in new int[eventsCount])
       aggregate.Apply(new SnapshotEvent());
 
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var snapshotResult = await RecordStore
+    var snapshotResult = await GetRecordStore()
       .GetSnapshots<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
       .SingleOrDefaultAsync();
 
-    var eventCount = await RecordStore
+    var eventCount = await GetRecordStore()
       .GetEvents<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -79,15 +79,15 @@ public abstract partial class EventSourcingTests
     foreach (var _ in new int[eventsCount])
       aggregate.Apply(new SnapshotEvent());
 
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var snapshotCount = await RecordStore
+    var snapshotCount = await GetRecordStore()
       .GetSnapshots<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
       .CountAsync();
     
-    var eventCount = await RecordStore
+    var eventCount = await GetRecordStore()
       .GetEvents<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -107,15 +107,15 @@ public abstract partial class EventSourcingTests
     foreach (var _ in new int[eventsCount])
       aggregate.Apply(new SnapshotEvent());
 
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
     
-    var snapshotCount = await RecordStore
+    var snapshotCount = await GetRecordStore()
       .GetSnapshots<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
       .CountAsync();
     
-    var eventCount = await RecordStore
+    var eventCount = await GetRecordStore()
       .GetEvents<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -136,16 +136,16 @@ public abstract partial class EventSourcingTests
     foreach (var _ in new int[eventsCount])
     {
       aggregate.Apply(new SnapshotEvent());
-      await AggregateService.PersistAsync(aggregate);
+      await GetAggregateService().PersistAsync(aggregate);
     }
 
-    var snapshotResult = await RecordStore
+    var snapshotResult = await GetRecordStore()
       .GetSnapshots<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
       .SingleOrDefaultAsync();
 
-    var eventCount = await RecordStore
+    var eventCount = await GetRecordStore()
       .GetEvents<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -169,7 +169,7 @@ public abstract partial class EventSourcingTests
     bankAccount.Apply(new BankAccountFundsTransferredEvent(50, bankAccount.Id, bankAccount2.Id));
     bankAccount.Apply(new BankAccountFundsWithdrawnEvent(20));
     bankAccount.Apply(new BankAccountFundsDepositedEvent(500));
-    await AggregateService.PersistAsync(bankAccount);
+    await GetAggregateService().PersistAsync(bankAccount);
   }
 
   [Fact]
@@ -177,11 +177,11 @@ public abstract partial class EventSourcingTests
   {
     var empty = new EmptyAggregate();
     empty.Apply(new EmptyEvent());
-    await AggregateService.PersistAsync(empty);
+    await GetAggregateService().PersistAsync(empty);
     
-    var emptyProjection = await RecordStore.GetProjectionByIdAsync<EmptyProjection>(empty.Id);
-    var anotherEmptyProjection = await RecordStore.GetProjectionByIdAsync<AnotherEmptyProjection>(empty.Id);
-    var nullProjection = await RecordStore.GetProjectionByIdAsync<NullProjection>(empty.Id);
+    var emptyProjection = await GetRecordStore().GetProjectionByIdAsync<EmptyProjection>(empty.Id);
+    var anotherEmptyProjection = await GetRecordStore().GetProjectionByIdAsync<AnotherEmptyProjection>(empty.Id);
+    var nullProjection = await GetRecordStore().GetProjectionByIdAsync<NullProjection>(empty.Id);
     
     Assert.NotNull(emptyProjection);
     Assert.NotNull(anotherEmptyProjection);
@@ -193,24 +193,24 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = new HierarchyAggregate();
     aggregate.Apply(new HierarchyEvent("Long String", "Tiny", "Small"));
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var projectionA = await RecordStore.GetProjectionByIdAsync<HierarchyProjection>(aggregate.Id);
+    var projectionA = await GetRecordStore().GetProjectionByIdAsync<HierarchyProjection>(aggregate.Id);
     Assert.IsType<HierarchyProjectionA>(projectionA);
     
-    var projectionALiteral = await RecordStore.GetProjectionByIdAsync<HierarchyProjectionA>(aggregate.Id);
+    var projectionALiteral = await GetRecordStore().GetProjectionByIdAsync<HierarchyProjectionA>(aggregate.Id);
     Assert.IsType<HierarchyProjectionA>(projectionALiteral);
 
     aggregate.Apply(new HierarchyEvent("Tiny", "Long String", "Small"));
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
     
-    var projectionB = await RecordStore.GetProjectionByIdAsync<HierarchyProjection>(aggregate.Id);
+    var projectionB = await GetRecordStore().GetProjectionByIdAsync<HierarchyProjection>(aggregate.Id);
     Assert.IsType<HierarchyProjectionB>(projectionB);
 
     aggregate.Apply(new HierarchyEvent("Small", "Tiny", "Long String"));
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
     
-    var projectionC = await RecordStore.GetProjectionByIdAsync<HierarchyProjection>(aggregate.Id);
+    var projectionC = await GetRecordStore().GetProjectionByIdAsync<HierarchyProjection>(aggregate.Id);
     Assert.IsType<HierarchyProjectionC>(projectionC);
   }
 }

--- a/EventSourcing.Core.Tests/AggregateServiceTests/RehydrateAndPersistAsync.cs
+++ b/EventSourcing.Core.Tests/AggregateServiceTests/RehydrateAndPersistAsync.cs
@@ -12,11 +12,11 @@ public abstract partial class EventSourcingTests
       aggregate.Apply(new SimpleEvent()),
     };
 
-    await AggregateService.PersistAsync(aggregate);
-    await AggregateService.RehydrateAndPersistAsync<SimpleAggregate>(aggregate.Id,
+    await GetAggregateService().PersistAsync(aggregate);
+    await GetAggregateService().RehydrateAndPersistAsync<SimpleAggregate>(aggregate.Id,
       a => a.Apply(new SimpleEvent()));
 
-    var count = await RecordStore
+    var count = await GetRecordStore()
       .GetEvents<SimpleAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -51,9 +51,9 @@ public abstract partial class EventSourcingTests
       MockStringSet = new List<string> { "A", "B", "C", "C" }
     });
 
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var result = await AggregateService.RehydrateAsync<MockAggregate>(aggregate.Id);
+    var result = await GetAggregateService().RehydrateAsync<MockAggregate>(aggregate.Id);
 
     IMock.AssertEqual(e, result!);
   }
@@ -68,11 +68,11 @@ public abstract partial class EventSourcingTests
       aggregate.Apply(new SimpleEvent()),
     };
 
-    await AggregateService.PersistAsync(aggregate);
-    await AggregateService.RehydrateAndPersistAsync<SimpleAggregate>(aggregate.PartitionId, aggregate.Id,
+    await GetAggregateService().PersistAsync(aggregate);
+    await GetAggregateService().RehydrateAndPersistAsync<SimpleAggregate>(aggregate.PartitionId, aggregate.Id,
       a => a.Apply(new SimpleEvent()));
 
-    var count = await RecordStore
+    var count = await GetRecordStore()
       .GetEvents<SimpleAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()

--- a/EventSourcing.Core.Tests/AggregateServiceTests/RehydrateAsync.cs
+++ b/EventSourcing.Core.Tests/AggregateServiceTests/RehydrateAsync.cs
@@ -13,9 +13,9 @@ public abstract partial class EventSourcingTests
       aggregate.Apply(new SimpleEvent())
     };
 
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var rehydrated = await AggregateService.RehydrateAsync<SimpleAggregate>(aggregate.Id);
+    var rehydrated = await GetAggregateService().RehydrateAsync<SimpleAggregate>(aggregate.Id);
 
     Assert.Equal(events.Count, rehydrated?.Counter);
   }
@@ -28,9 +28,9 @@ public abstract partial class EventSourcingTests
     aggregate.Apply(new SimpleEvent());
     aggregate.Apply(new SimpleEvent { Timestamp = DateTimeOffset.UtcNow.AddYears(1) });
 
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var rehydrated = await AggregateService.RehydrateAsync<SimpleAggregate>(aggregate.Id, DateTimeOffset.UtcNow);
+    var rehydrated = await GetAggregateService().RehydrateAsync<SimpleAggregate>(aggregate.Id, DateTimeOffset.UtcNow);
 
     Assert.Equal(2, rehydrated?.Counter);
   }
@@ -38,7 +38,7 @@ public abstract partial class EventSourcingTests
   [Fact]
   public async Task AggregateService_RehydrateAsync_Rehydrating_Aggregate_Returns_Null_When_No_Events_Are_Found()
   {
-    Assert.Null(await AggregateService.RehydrateAsync<EmptyAggregate>(Guid.NewGuid()));
+    Assert.Null(await GetAggregateService().RehydrateAsync<EmptyAggregate>(Guid.NewGuid()));
   }
 
   [Fact]
@@ -51,8 +51,8 @@ public abstract partial class EventSourcingTests
     foreach (var _ in new int[eventsCount])
       aggregate.Apply(new SnapshotEvent());
 
-    await AggregateService.PersistAsync(aggregate);
-    var result = await AggregateService.RehydrateAsync<SnapshotAggregate>(aggregate.Id);
+    await GetAggregateService().PersistAsync(aggregate);
+    var result = await GetAggregateService().RehydrateAsync<SnapshotAggregate>(aggregate.Id);
 
     Assert.NotNull(result);
     Assert.Equal((int)eventsCount, result?.Counter);
@@ -68,11 +68,11 @@ public abstract partial class EventSourcingTests
 
     foreach (var _ in new int[factory.SnapshotInterval])
       aggregate.Apply(new SnapshotEvent());
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
     foreach (var _ in new int[3])
       aggregate.Apply(new SnapshotEvent());
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
     await Task.Delay(100);
     var date = DateTimeOffset.UtcNow;
@@ -80,17 +80,17 @@ public abstract partial class EventSourcingTests
 
     foreach (var _ in new int[factory.SnapshotInterval])
       aggregate.Apply(new SnapshotEvent());
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var result = await AggregateService.RehydrateAsync<SnapshotAggregate>(aggregate.Id, date);
+    var result = await GetAggregateService().RehydrateAsync<SnapshotAggregate>(aggregate.Id, date);
 
-    var snapshotCount = await RecordStore
+    var snapshotCount = await GetRecordStore()
       .GetSnapshots<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
       .CountAsync();
 
-    var eventsCount = await RecordStore
+    var eventsCount = await GetRecordStore()
       .GetEvents<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -114,19 +114,19 @@ public abstract partial class EventSourcingTests
 
     foreach (var _ in new int[eventsCount])
       aggregate.Apply(new SnapshotEvent());
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
     foreach (var _ in new int[eventsCount])
       aggregate.Apply(new SnapshotEvent());
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
     foreach (var _ in new int[eventsCount - 1])
       aggregate.Apply(new SnapshotEvent());
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var result = await AggregateService.RehydrateAsync<SnapshotAggregate>(aggregate.Id);
+    var result = await GetAggregateService().RehydrateAsync<SnapshotAggregate>(aggregate.Id);
 
-    var snapshotCount = await RecordStore
+    var snapshotCount = await GetRecordStore()
       .GetSnapshots<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -149,15 +149,15 @@ public abstract partial class EventSourcingTests
 
     foreach (var _ in new int[eventsCount])
       aggregate.Apply(new SnapshotEvent());
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
     foreach (var _ in new int[eventsCount - 1])
       aggregate.Apply(new SnapshotEvent());
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var result = await AggregateService.RehydrateAsync<SnapshotAggregate>(aggregate.Id);
+    var result = await GetAggregateService().RehydrateAsync<SnapshotAggregate>(aggregate.Id);
 
-    var snapshotCount = await RecordStore
+    var snapshotCount = await GetRecordStore()
       .GetSnapshots<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()

--- a/EventSourcing.Core.Tests/BankAccountScenarioTests.cs
+++ b/EventSourcing.Core.Tests/BankAccountScenarioTests.cs
@@ -19,7 +19,7 @@ public abstract partial class EventSourcingTests
     Assert.Equal("SOME IBAN", account.Iban);
     Assert.Equal(100, account.Balance);
     
-    await AggregateService.PersistAsync(account);
+    await GetAggregateService().PersistAsync(account);
   }
 
   [Fact]
@@ -28,11 +28,11 @@ public abstract partial class EventSourcingTests
     var account = new BankAccount();
     account.Apply(new BankAccountCreatedEvent("E. Sourcing", "SOME IBAN"));
     account.Apply(new BankAccountFundsDepositedEvent(100));
-    await AggregateService.PersistAsync(account);
+    await GetAggregateService().PersistAsync(account);
 
-    var aggregate = await AggregateService.RehydrateAsync<BankAccount>(account.Id);
+    var aggregate = await GetAggregateService().RehydrateAsync<BankAccount>(account.Id);
     aggregate!.Apply(new BankAccountFundsDepositedEvent(50));
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
   }
 
   [Fact]
@@ -41,9 +41,9 @@ public abstract partial class EventSourcingTests
     var account = new BankAccount();
     account.Apply(new BankAccountCreatedEvent("E. Sourcing", "SOME IBAN"));
     account.Apply(new BankAccountFundsDepositedEvent(100));
-    await AggregateService.PersistAsync(account);
+    await GetAggregateService().PersistAsync(account);
 
-    await AggregateService.RehydrateAndPersistAsync<BankAccount>(account.Id, 
+    await GetAggregateService().RehydrateAndPersistAsync<BankAccount>(account.Id, 
       x => x.Apply(new BankAccountFundsDepositedEvent(50)));
   }
 
@@ -53,7 +53,7 @@ public abstract partial class EventSourcingTests
     var account = new BankAccount();
     account.Apply(new BankAccountCreatedEvent("E. Sourcing", "SOME IBAN"));
     account.Apply(new BankAccountFundsDepositedEvent(100));
-    await AggregateService.PersistAsync(account);
+    await GetAggregateService().PersistAsync(account);
 
     var anotherAccount = new BankAccount();
     anotherAccount.Apply(new BankAccountCreatedEvent("E. Sourcing", "SOME OTHER IBAN"));
@@ -63,13 +63,13 @@ public abstract partial class EventSourcingTests
     account.Apply(transfer);
     anotherAccount.Apply(transfer);
 
-    var transaction = AggregateService.CreateTransaction();
+    var transaction = GetAggregateService().CreateTransaction();
     await transaction.AddAggregateAsync(account);
     await transaction.AddAggregateAsync(anotherAccount);
     await transaction.CommitAsync();
 
-    var result1 = await AggregateService.RehydrateAsync<BankAccount>(account.Id);
-    var result2 = await AggregateService.RehydrateAsync<BankAccount>(anotherAccount.Id);
+    var result1 = await GetAggregateService().RehydrateAsync<BankAccount>(account.Id);
+    var result2 = await GetAggregateService().RehydrateAsync<BankAccount>(anotherAccount.Id);
 
     Assert.Equal(account.Name, result1?.Name);
     Assert.Equal(account.Iban, result1?.Iban);

--- a/EventSourcing.Core.Tests/EventSourcingTests.cs
+++ b/EventSourcing.Core.Tests/EventSourcingTests.cs
@@ -2,7 +2,9 @@ namespace Finaps.EventSourcing.Core.Tests;
 
 public abstract partial class EventSourcingTests
 {
-  protected abstract IRecordStore RecordStore { get; }
-  protected IAggregateService AggregateService => new AggregateService(RecordStore);
-  protected IProjectionUpdateService ProjectionUpdateService => new ProjectionUpdateService(AggregateService, RecordStore);
+  protected abstract IRecordStore GetRecordStore();
+  protected IAggregateService GetAggregateService() => new AggregateService(GetRecordStore());
+
+  protected IProjectionUpdateService GetProjectionUpdateService() => 
+    new ProjectionUpdateService(GetAggregateService(), GetRecordStore());
 }

--- a/EventSourcing.Core.Tests/ProjectionUpdateServiceTests/UpdateAllProjectionsAsync.cs
+++ b/EventSourcing.Core.Tests/ProjectionUpdateServiceTests/UpdateAllProjectionsAsync.cs
@@ -7,7 +7,7 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = MockAggregate.Create();
 
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
     var defaultProjection = new MockAggregateProjection
     {
@@ -25,9 +25,9 @@ public abstract partial class EventSourcingTests
       MockStringSet = new List<string>()
     };
 
-    await RecordStore.UpsertProjectionAsync(defaultProjection);
+    await GetRecordStore().UpsertProjectionAsync(defaultProjection);
     
-    var before = await RecordStore
+    var before = await GetRecordStore()
       .GetProjections<MockAggregateProjection>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -35,9 +35,9 @@ public abstract partial class EventSourcingTests
     
     IMock.AssertDefault(before);
 
-    await ProjectionUpdateService.UpdateAllProjectionsAsync<MockAggregate, MockAggregateProjection>();
+    await GetProjectionUpdateService().UpdateAllProjectionsAsync<MockAggregate, MockAggregateProjection>();
 
-    var after = await RecordStore
+    var after = await GetRecordStore()
       .GetProjections<MockAggregateProjection>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()

--- a/EventSourcing.Core.Tests/RecordStoreTests/AddSnapshotAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/AddSnapshotAsync.cs
@@ -7,11 +7,11 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = new SnapshotAggregate();
     var e = aggregate.Apply(new SnapshotEvent());
-    await RecordStore.AddEventsAsync(new [] { e });
+    await GetRecordStore().AddEventsAsync(new [] { e });
     
     var factory = new SimpleSnapshotFactory();
     
-    await RecordStore.AddSnapshotAsync(factory.CreateSnapshot(aggregate));
+    await GetRecordStore().AddSnapshotAsync(factory.CreateSnapshot(aggregate));
   }
   
   [Fact]
@@ -19,14 +19,14 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = new SnapshotAggregate();
     var e = aggregate.Apply(new SnapshotEvent());
-    await RecordStore.AddEventsAsync(new [] { e });
+    await GetRecordStore().AddEventsAsync(new [] { e });
 
     var factory = new SimpleSnapshotFactory();
 
     var snapshot = factory.CreateSnapshot(aggregate);
-    await RecordStore.AddSnapshotAsync(snapshot);
+    await GetRecordStore().AddSnapshotAsync(snapshot);
 
     await Assert.ThrowsAsync<RecordStoreException>(async () => 
-      await RecordStore.AddSnapshotAsync(snapshot));
+      await GetRecordStore().AddSnapshotAsync(snapshot));
   }
 }

--- a/EventSourcing.Core.Tests/RecordStoreTests/DeleteAggregateAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/DeleteAggregateAsync.cs
@@ -11,11 +11,11 @@ public abstract partial class EventSourcingTests
     for (var i = 0; i < 3; i++)
       events.Add(aggregate.Apply(new EmptyEvent()));
 
-    await RecordStore.AddEventsAsync(events);
+    await GetRecordStore().AddEventsAsync(events);
 
-    var deleted = await RecordStore.DeleteAggregateAsync<EmptyAggregate>(Guid.Empty, aggregate.Id);
+    var deleted = await GetRecordStore().DeleteAggregateAsync<EmptyAggregate>(Guid.Empty, aggregate.Id);
 
-    var count = await RecordStore
+    var count = await GetRecordStore()
       .GetEvents<EmptyAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -32,8 +32,8 @@ public abstract partial class EventSourcingTests
 
     // Store event
     var e = aggregate.Apply(new EmptyEvent());
-    await RecordStore.AddEventsAsync(new Event<EmptyAggregate>[] { e });
-    Assert.NotNull(await RecordStore
+    await GetRecordStore().AddEventsAsync(new Event<EmptyAggregate>[] { e });
+    Assert.NotNull(await GetRecordStore()
       .GetEvents<EmptyAggregate>()
       .Where(x => x.AggregateId == e.AggregateId)
       .AsAsyncEnumerable()
@@ -41,8 +41,8 @@ public abstract partial class EventSourcingTests
 
     // Store snapshot
     var snapshot = new EmptySnapshot { AggregateId = aggregate.Id, AggregateType = nameof(EmptyAggregate) };
-    await RecordStore.AddSnapshotAsync(snapshot);
-    Assert.NotNull(await RecordStore
+    await GetRecordStore().AddSnapshotAsync(snapshot);
+    Assert.NotNull(await GetRecordStore()
       .GetSnapshots<EmptyAggregate>()
       .Where(x => x.AggregateId == snapshot.AggregateId)
       .AsAsyncEnumerable()
@@ -51,25 +51,25 @@ public abstract partial class EventSourcingTests
     // Store projection
     var projection = new EmptyProjection
       { AggregateId = aggregate.Id, AggregateType = nameof(EmptyAggregate), Hash = "RANDOM" };
-    await RecordStore.UpsertProjectionAsync(projection);
-    Assert.NotNull(await RecordStore.GetProjectionByIdAsync<EmptyProjection>(projection.AggregateId));
+    await GetRecordStore().UpsertProjectionAsync(projection);
+    Assert.NotNull(await GetRecordStore().GetProjectionByIdAsync<EmptyProjection>(projection.AggregateId));
 
     // Delete all items created
-    await RecordStore.DeleteAggregateAsync<EmptyAggregate>(Guid.Empty, aggregate.Id);
+    await GetRecordStore().DeleteAggregateAsync<EmptyAggregate>(Guid.Empty, aggregate.Id);
     
-    var eventsCount = await RecordStore
+    var eventsCount = await GetRecordStore()
       .GetEvents<EmptyAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
       .CountAsync();
 
-    var snapshotsCount = await RecordStore
+    var snapshotsCount = await GetRecordStore()
       .GetSnapshots<EmptyAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
       .CountAsync();
 
-    var projectionsCount = await RecordStore.GetProjections<EmptyProjection>()
+    var projectionsCount = await GetRecordStore().GetProjections<EmptyProjection>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
       .CountAsync();
@@ -82,7 +82,7 @@ public abstract partial class EventSourcingTests
   [Fact]
   public async Task RecordStore_DeleteAggregateAsync_Can_Delete_More_Than_100_Events()
   {
-    var store = RecordStore;
+    var store = GetRecordStore();
     
     var aggregate = new EmptyAggregate();
 

--- a/EventSourcing.Core.Tests/RecordStoreTests/DeleteAllEventsAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/DeleteAllEventsAsync.cs
@@ -12,11 +12,11 @@ public abstract partial class EventSourcingTests
       .Select(_ => aggregate.Apply(new EmptyEvent()))
       .ToArray();
 
-    await RecordStore.AddEventsAsync(events);
+    await GetRecordStore().AddEventsAsync(events);
 
-    await RecordStore.DeleteAllEventsAsync<EmptyAggregate>(aggregate.Id);
+    await GetRecordStore().DeleteAllEventsAsync<EmptyAggregate>(aggregate.Id);
 
-    var count = await RecordStore
+    var count = await GetRecordStore()
       .GetEvents<EmptyAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -37,19 +37,19 @@ public abstract partial class EventSourcingTests
       .Select(_ => aggregate.Apply(new EmptyEvent()))
       .ToArray();
     
-    await RecordStore.AddEventsAsync(events);
-    await RecordStore.AddSnapshotAsync(snapshot);
-    await RecordStore.UpsertProjectionAsync(projection);
+    await GetRecordStore().AddEventsAsync(events);
+    await GetRecordStore().AddSnapshotAsync(snapshot);
+    await GetRecordStore().UpsertProjectionAsync(projection);
     
-    await RecordStore.DeleteAllEventsAsync<EmptyAggregate>(aggregate.Id);
+    await GetRecordStore().DeleteAllEventsAsync<EmptyAggregate>(aggregate.Id);
 
-    var eventCount = await RecordStore
+    var eventCount = await GetRecordStore()
       .GetEvents<EmptyAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
       .CountAsync();
 
-    var projectionResult = await RecordStore.GetProjectionByIdAsync<EmptyProjection>(aggregate.Id);
+    var projectionResult = await GetRecordStore().GetProjectionByIdAsync<EmptyProjection>(aggregate.Id);
     
     Assert.Equal(0, eventCount);
     Assert.NotNull(projectionResult);
@@ -65,11 +65,11 @@ public abstract partial class EventSourcingTests
       .Select(_ => aggregate.Apply(new EmptyEvent()))
       .ToArray();
     
-    await RecordStore.AddEventsAsync(events);
+    await GetRecordStore().AddEventsAsync(events);
 
-    var deleted = await RecordStore.DeleteAllEventsAsync<EmptyAggregate>(aggregate.Id);
+    var deleted = await GetRecordStore().DeleteAllEventsAsync<EmptyAggregate>(aggregate.Id);
 
-    var count = await RecordStore
+    var count = await GetRecordStore()
       .GetEvents<EmptyAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()

--- a/EventSourcing.Core.Tests/RecordStoreTests/DeleteAllSnapshotsAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/DeleteAllSnapshotsAsync.cs
@@ -5,7 +5,7 @@ public abstract partial class EventSourcingTests
     [Fact]
     public async Task RecordStore_DeleteAllSnapshotsAsync_Can_Delete_Snapshots()
     {
-        var store = RecordStore;
+        var store = GetRecordStore();
         
         var aggregate = new SnapshotAggregate();
         var factory = new SimpleSnapshotFactory();
@@ -49,26 +49,26 @@ public abstract partial class EventSourcingTests
             .Select(_ => aggregate.Apply(new EmptyEvent()))
             .ToArray();
 
-        await RecordStore.AddEventsAsync(events);
-        await RecordStore.AddSnapshotAsync(snapshot);
-        await RecordStore.AddSnapshotAsync(snapshot2);
-        await RecordStore.UpsertProjectionAsync(projection);
+        await GetRecordStore().AddEventsAsync(events);
+        await GetRecordStore().AddSnapshotAsync(snapshot);
+        await GetRecordStore().AddSnapshotAsync(snapshot2);
+        await GetRecordStore().UpsertProjectionAsync(projection);
     
-        await RecordStore.DeleteAllSnapshotsAsync<EmptyAggregate>(aggregate.Id);
+        await GetRecordStore().DeleteAllSnapshotsAsync<EmptyAggregate>(aggregate.Id);
 
-        var eventCount = await RecordStore
+        var eventCount = await GetRecordStore()
             .GetEvents<EmptyAggregate>()
             .Where(x => x.AggregateId == aggregate.Id)
             .AsAsyncEnumerable()
             .CountAsync();
 
-        var snapshotCount = await RecordStore
+        var snapshotCount = await GetRecordStore()
             .GetSnapshots<EmptyAggregate>()
             .Where(x => x.AggregateId == aggregate.Id)
             .AsAsyncEnumerable()
             .CountAsync();
     
-        var projectionResult = await RecordStore.GetProjectionByIdAsync<EmptyProjection>(aggregate.Id);
+        var projectionResult = await GetRecordStore().GetProjectionByIdAsync<EmptyProjection>(aggregate.Id);
     
         Assert.Equal(3, eventCount);
         Assert.Equal(0, snapshotCount);
@@ -78,7 +78,7 @@ public abstract partial class EventSourcingTests
     [Fact]
     public async Task RecordStore_DeleteAllSnapshotsAsync_Correctly_Returns_Deleted_Count()
     {
-        var store = RecordStore;
+        var store = GetRecordStore();
         
         var aggregate = new SnapshotAggregate();
         var factory = new SimpleSnapshotFactory();

--- a/EventSourcing.Core.Tests/RecordStoreTests/DeleteProjectionAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/DeleteProjectionAsync.cs
@@ -6,12 +6,12 @@ public abstract partial class EventSourcingTests
   public async Task RecordStore_DeleteProjectionAsync_Can_Delete_Projection()
   {
     var projection = new EmptyProjection { AggregateId = Guid.NewGuid(), AggregateType = nameof(EmptyAggregate), Hash = "RANDOM" };
-    await RecordStore.UpsertProjectionAsync(projection);
+    await GetRecordStore().UpsertProjectionAsync(projection);
 
-    Assert.NotNull(await RecordStore.GetProjectionByIdAsync<EmptyProjection>(projection.AggregateId));
+    Assert.NotNull(await GetRecordStore().GetProjectionByIdAsync<EmptyProjection>(projection.AggregateId));
 
-    await RecordStore.DeleteProjectionAsync<EmptyProjection>(projection.AggregateId);
+    await GetRecordStore().DeleteProjectionAsync<EmptyProjection>(projection.AggregateId);
     
-    Assert.Null(await RecordStore.GetProjectionByIdAsync<EmptyProjection>(projection.AggregateId));
+    Assert.Null(await GetRecordStore().GetProjectionByIdAsync<EmptyProjection>(projection.AggregateId));
   }
 }

--- a/EventSourcing.Core.Tests/RecordStoreTests/DeleteSnapshotAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/DeleteSnapshotAsync.cs
@@ -7,21 +7,21 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = new SnapshotAggregate();
     var e = aggregate.Apply(new SnapshotEvent());
-    await RecordStore.AddEventsAsync(new [] { e });
+    await GetRecordStore().AddEventsAsync(new [] { e });
 
     var factory = new SimpleSnapshotFactory();
     var snapshot = factory.CreateSnapshot(aggregate);
-    await RecordStore.AddSnapshotAsync(snapshot);
+    await GetRecordStore().AddSnapshotAsync(snapshot);
 
-    Assert.NotNull(await RecordStore
+    Assert.NotNull(await GetRecordStore()
       .GetSnapshots<SnapshotAggregate>()
       .Where(x => x.AggregateId == snapshot.AggregateId)
       .AsAsyncEnumerable()
       .SingleAsync());
 
-    await RecordStore.DeleteSnapshotAsync<SnapshotAggregate>(snapshot.AggregateId, snapshot.Index);
+    await GetRecordStore().DeleteSnapshotAsync<SnapshotAggregate>(snapshot.AggregateId, snapshot.Index);
 
-    Assert.False(await RecordStore
+    Assert.False(await GetRecordStore()
       .GetSnapshots<SnapshotAggregate>()
       .Where(x => x.AggregateId == snapshot.AggregateId)
       .AsAsyncEnumerable()

--- a/EventSourcing.Core.Tests/RecordStoreTests/GetEvents.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/GetEvents.cs
@@ -14,9 +14,9 @@ public abstract partial class EventSourcingTests
       aggregate1.Apply(new EmptyEvent())
     };
 
-    await RecordStore.AddEventsAsync(events1);
+    await GetRecordStore().AddEventsAsync(events1);
 
-    var count = await RecordStore
+    var count = await GetRecordStore()
       .GetEvents<EmptyAggregate>()
       .Where(x => x.PartitionId == aggregate1.PartitionId)
       .AsAsyncEnumerable()
@@ -37,9 +37,9 @@ public abstract partial class EventSourcingTests
       aggregate.Apply(new EmptyEvent())
     };
 
-    await RecordStore.AddEventsAsync(events);
+    await GetRecordStore().AddEventsAsync(events);
 
-    var count = await RecordStore
+    var count = await GetRecordStore()
       .GetEvents<EmptyAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -65,10 +65,10 @@ public abstract partial class EventSourcingTests
       aggregate2.Apply(new EmptyEvent())
     };
 
-    await RecordStore.AddEventsAsync(events);
-    await RecordStore.AddEventsAsync(events2);
+    await GetRecordStore().AddEventsAsync(events);
+    await GetRecordStore().AddEventsAsync(events2);
 
-    var result = await RecordStore
+    var result = await GetRecordStore()
       .GetEvents<EmptyAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .Where(x => x.Index > 0)
@@ -95,13 +95,13 @@ public abstract partial class EventSourcingTests
       aggregate2.Apply(new SimpleEvent())
     };
 
-    await RecordStore.AddEventsAsync(events);
-    await RecordStore.AddEventsAsync(events2);
+    await GetRecordStore().AddEventsAsync(events);
+    await GetRecordStore().AddEventsAsync(events2);
 
     // If I just would query all events by Type, I'd get all events from the history of tests
     // Therefore I test the same thing by two assertions.
 
-    var result = await RecordStore
+    var result = await GetRecordStore()
       .GetEvents<EmptyAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -109,7 +109,7 @@ public abstract partial class EventSourcingTests
 
     Assert.All(result, e => Assert.Equal(aggregate.Id, e.AggregateId));
 
-    var result2 = await RecordStore
+    var result2 = await GetRecordStore()
       .GetEvents<EmptyAggregate>()
       .Where(x => x.AggregateId == aggregate2.Id)
       .AsAsyncEnumerable()
@@ -142,9 +142,9 @@ public abstract partial class EventSourcingTests
       MockStringSet = new List<string> { "A", "B", "C", "C" }
     });
 
-    await RecordStore.AddEventsAsync(new [] { e });
+    await GetRecordStore().AddEventsAsync(new [] { e });
 
-    var result = (await RecordStore
+    var result = (await GetRecordStore()
         .GetEvents<MockAggregate>()
         .Where(x => x.AggregateId == aggregate.Id)
         .AsAsyncEnumerable()

--- a/EventSourcing.Core.Tests/RecordStoreTests/GetProjections.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/GetProjections.cs
@@ -7,9 +7,9 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = MockAggregate.Create();
 
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var projection = await RecordStore
+    var projection = await GetRecordStore()
       .GetProjections<MockAggregateProjection>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -23,9 +23,9 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = MockAggregate.Create();
 
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var projection = await RecordStore.GetProjectionByIdAsync<MockAggregateProjection>(aggregate.Id);
+    var projection = await GetRecordStore().GetProjectionByIdAsync<MockAggregateProjection>(aggregate.Id);
     
     IMock.AssertEqual(aggregate, projection!);
   }
@@ -45,10 +45,10 @@ public abstract partial class EventSourcingTests
           _ => new HierarchyEvent("A", "B", "CC")
         }
       );
-      await AggregateService.PersistAsync(aggregate);
+      await GetAggregateService().PersistAsync(aggregate);
     }
     
-    var projections = await RecordStore.GetProjections<HierarchyProjection>()
+    var projections = await GetRecordStore().GetProjections<HierarchyProjection>()
       .Where(x => x.PartitionId == partitionId)
       .AsAsyncEnumerable()
       .ToListAsync();

--- a/EventSourcing.Core.Tests/RecordStoreTests/GetSnapshots.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/GetSnapshots.cs
@@ -7,12 +7,12 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = new SnapshotAggregate { PartitionId = Guid.NewGuid() };
     var e = aggregate.Apply(new SnapshotEvent());
-    await RecordStore.AddEventsAsync(new [] { e });
+    await GetRecordStore().AddEventsAsync(new [] { e });
     
     var factory = new SimpleSnapshotFactory();
-    await RecordStore.AddSnapshotAsync(factory.CreateSnapshot(aggregate));
+    await GetRecordStore().AddSnapshotAsync(factory.CreateSnapshot(aggregate));
 
-    var count = await RecordStore
+    var count = await GetRecordStore()
       .GetSnapshots<SnapshotAggregate>()
       .Where(x => x.PartitionId == aggregate.PartitionId)
       .AsAsyncEnumerable()
@@ -26,12 +26,12 @@ public abstract partial class EventSourcingTests
   {
     var aggregate = new SnapshotAggregate();
     var e = aggregate.Apply(new SnapshotEvent());
-    await RecordStore.AddEventsAsync(new [] { e });
+    await GetRecordStore().AddEventsAsync(new [] { e });
 
     var factory = new SimpleSnapshotFactory();
-    await RecordStore.AddSnapshotAsync(factory.CreateSnapshot(aggregate));
+    await GetRecordStore().AddSnapshotAsync(factory.CreateSnapshot(aggregate));
 
-    var count = await RecordStore
+    var count = await GetRecordStore()
       .GetSnapshots<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -46,7 +46,7 @@ public abstract partial class EventSourcingTests
     var aggregate = new SnapshotAggregate();
     var e1 = aggregate.Apply(new SnapshotEvent());
 
-    var store = RecordStore;
+    var store = GetRecordStore();
 
     await store.AddEventsAsync(new [] { e1 });
     
@@ -64,7 +64,7 @@ public abstract partial class EventSourcingTests
     await store.AddSnapshotAsync(snapshot1);
     await store.AddSnapshotAsync(snapshot2);
 
-    var result = await RecordStore
+    var result = await GetRecordStore()
       .GetSnapshots<SnapshotAggregate>()
       .Where(x => x.AggregateId == aggregate.Id)
       .OrderByDescending(x => x.Index)

--- a/EventSourcing.Core.Tests/RecordStoreTests/UpsertProjectionAsync.cs
+++ b/EventSourcing.Core.Tests/RecordStoreTests/UpsertProjectionAsync.cs
@@ -25,9 +25,9 @@ public abstract partial class EventSourcingTests
     });
 
     // Create Projection
-    await RecordStore.UpsertProjectionAsync(new MockAggregateProjectionFactory().CreateProjection(aggregate)!);
+    await GetRecordStore().UpsertProjectionAsync(new MockAggregateProjectionFactory().CreateProjection(aggregate)!);
     
-    var projection = await RecordStore
+    var projection = await GetRecordStore()
       .GetProjections<MockAggregateProjection>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()
@@ -64,9 +64,9 @@ public abstract partial class EventSourcingTests
     });
 
     // Update Projection
-    await RecordStore.UpsertProjectionAsync(new MockAggregateProjectionFactory().CreateProjection(aggregate)!);
+    await GetRecordStore().UpsertProjectionAsync(new MockAggregateProjectionFactory().CreateProjection(aggregate)!);
     
-    var updatedProjection = await RecordStore
+    var updatedProjection = await GetRecordStore()
       .GetProjections<MockAggregateProjection>()
       .Where(x => x.AggregateId == aggregate.Id)
       .AsAsyncEnumerable()

--- a/EventSourcing.Core.Tests/RecordTransactionTests/AddSnapshot.cs
+++ b/EventSourcing.Core.Tests/RecordTransactionTests/AddSnapshot.cs
@@ -10,12 +10,12 @@ public abstract partial class EventSourcingTests
         var s = new SnapshotSnapshot 
             { AggregateId = e.AggregateId, AggregateType = nameof(SnapshotAggregate), Index = 0, Counter = 10};
         
-        await RecordStore.CreateTransaction()
+        await GetRecordStore().CreateTransaction()
             .AddEvents(new List<Event<SnapshotAggregate>> { e })
             .AddSnapshot(s)
             .CommitAsync();
 
-        var snapshot = await RecordStore
+        var snapshot = await GetRecordStore()
             .GetSnapshots<SnapshotAggregate>()
             .Where(x => x.AggregateId == s.AggregateId)
             .AsAsyncEnumerable()
@@ -30,10 +30,10 @@ public abstract partial class EventSourcingTests
     {
         var s = new SnapshotSnapshot { AggregateId = Guid.NewGuid(), AggregateType = nameof(SnapshotAggregate) , Index = -1};
 
-        var transaction = RecordStore.CreateTransaction();
+        var transaction = GetRecordStore().CreateTransaction();
         Assert.Throws<RecordValidationException>(() => transaction.AddSnapshot(s));
 
-        var count = await RecordStore
+        var count = await GetRecordStore()
             .GetSnapshots<SnapshotAggregate>()
             .Where(x => x.AggregateId == s.AggregateId)
             .AsAsyncEnumerable()

--- a/EventSourcing.Core.Tests/RecordTransactionTests/DeleteAllEvents.cs
+++ b/EventSourcing.Core.Tests/RecordTransactionTests/DeleteAllEvents.cs
@@ -15,15 +15,15 @@ public abstract partial class EventSourcingTests
                 Index = i
             }).ToList();
 
-        await RecordStore.CreateTransaction()
+        await GetRecordStore().CreateTransaction()
           .AddEvents(events)
           .CommitAsync();
         
-        await RecordStore.CreateTransaction()
+        await GetRecordStore().CreateTransaction()
             .DeleteAllEvents<EmptyAggregate>(aggregateId, events.Count - 1)
             .CommitAsync();
 
-        var count = await RecordStore
+        var count = await GetRecordStore()
             .GetEvents<EmptyAggregate>()
             .Where(x => x.AggregateId == aggregateId)
             .AsAsyncEnumerable()
@@ -45,7 +45,7 @@ public abstract partial class EventSourcingTests
                 Index = i
             }).ToList();
 
-        var transaction = RecordStore.CreateTransaction()
+        var transaction = GetRecordStore().CreateTransaction()
             .AddEvents(new List<Event<EmptyAggregate>>
             {
                 new EmptyEvent
@@ -59,7 +59,7 @@ public abstract partial class EventSourcingTests
 
         await Assert.ThrowsAsync<RecordStoreException>(async () => await transaction.CommitAsync());
         
-        var count = await RecordStore
+        var count = await GetRecordStore()
             .GetEvents<EmptyAggregate>()
             .Where(x => x.AggregateId == aggregateId)
             .AsAsyncEnumerable()

--- a/EventSourcing.Core.Tests/RecordTransactionTests/DeleteProjection.cs
+++ b/EventSourcing.Core.Tests/RecordTransactionTests/DeleteProjection.cs
@@ -8,9 +8,9 @@ public abstract partial class EventSourcingTests
         var e = new EmptyEvent();
         var a = new EmptyAggregate();
         a.Apply(e);
-        await AggregateService.PersistAsync(a);
+        await GetAggregateService().PersistAsync(a);
         
-        var countBefore = await RecordStore
+        var countBefore = await GetRecordStore()
             .GetProjections<EmptyProjection>()
             .Where(x => x.AggregateId == a.Id)
             .AsAsyncEnumerable()
@@ -18,11 +18,11 @@ public abstract partial class EventSourcingTests
     
         Assert.Equal(1, countBefore);
         
-        await RecordStore.CreateTransaction()
+        await GetRecordStore().CreateTransaction()
             .DeleteProjection<EmptyProjection>(a.Id)
             .CommitAsync();
 
-        var countAfter = await RecordStore
+        var countAfter = await GetRecordStore()
             .GetProjections<EmptyProjection>()
             .Where(x => x.AggregateId == a.Id)
             .AsAsyncEnumerable()

--- a/EventSourcing.Core.Tests/RecordTransactionTests/DeleteSnapshot.cs
+++ b/EventSourcing.Core.Tests/RecordTransactionTests/DeleteSnapshot.cs
@@ -15,19 +15,19 @@ public abstract partial class EventSourcingTests
         foreach (var snapshotEvent in events)
             a.Apply(snapshotEvent);
         
-        await AggregateService.PersistAsync(a);
+        await GetAggregateService().PersistAsync(a);
         
-        await RecordStore
+        await GetRecordStore()
             .GetSnapshots<SnapshotAggregate>()
             .Where(x => x.AggregateId == a.Id)
             .AsAsyncEnumerable()
             .SingleAsync();
         
-        await RecordStore.CreateTransaction()
+        await GetRecordStore().CreateTransaction()
             .DeleteSnapshot<SnapshotAggregate>(a.Id, events.Count - 1)
             .CommitAsync();
 
-        var countAfter = await RecordStore
+        var countAfter = await GetRecordStore()
             .GetSnapshots<SnapshotAggregate>()
             .Where(x => x.AggregateId == a.Id)
             .AsAsyncEnumerable()

--- a/EventSourcing.Core.Tests/RecordTransactionTests/UpsertProjection.cs
+++ b/EventSourcing.Core.Tests/RecordTransactionTests/UpsertProjection.cs
@@ -8,9 +8,9 @@ public abstract partial class EventSourcingTests
         var e = new EmptyEvent();
         var a = new EmptyAggregate();
         a.Apply(e);
-        await AggregateService.PersistAsync(a);
+        await GetAggregateService().PersistAsync(a);
 
-        var projectionBefore = await RecordStore
+        var projectionBefore = await GetRecordStore()
             .GetProjections<EmptyProjection>()
             .Where(x => x.AggregateId == a.Id)
             .AsAsyncEnumerable()
@@ -20,11 +20,11 @@ public abstract partial class EventSourcingTests
         
         Assert.NotEqual(projectionBefore.Timestamp, updatedProjection.Timestamp);
         
-        await RecordStore.CreateTransaction()
+        await GetRecordStore().CreateTransaction()
             .UpsertProjection(updatedProjection)
             .CommitAsync();
 
-        var result = await RecordStore
+        var result = await GetRecordStore()
             .GetProjections<EmptyProjection>()
             .Where(x => x.AggregateId == a.Id)
             .AsAsyncEnumerable()

--- a/EventSourcing.Core/EventSourcing.Core.csproj
+++ b/EventSourcing.Core/EventSourcing.Core.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <OutputType>Library</OutputType>
         <PackageId>Finaps.EventSourcing.Core</PackageId>
-        <Version>0.4.2</Version>
+        <Version>0.4.3</Version>
         <Authors>Niels Disveld, Bram Kraaijeveld</Authors>
         <Company>Finaps B.V.</Company>
         <RepositoryUrl>https://github.com/Finaps/EventSourcing</RepositoryUrl>

--- a/EventSourcing.Cosmos.Tests/CosmosEventSourcingTests.cs
+++ b/EventSourcing.Cosmos.Tests/CosmosEventSourcingTests.cs
@@ -14,8 +14,12 @@ namespace Finaps.EventSourcing.Cosmos.Tests;
 public partial class CosmosEventSourcingTests : EventSourcingTests
 {
   private readonly IOptions<CosmosRecordStoreOptions> _options;
+  private readonly IRecordStore _recordStore;
 
-  protected override IRecordStore RecordStore { get; }
+  protected override IRecordStore GetRecordStore()
+  {
+    return _recordStore;
+  }
 
   public CosmosEventSourcingTests()
   {
@@ -32,7 +36,7 @@ public partial class CosmosEventSourcingTests : EventSourcingTests
       Container = configuration["Cosmos:Container"]
     });
 
-    RecordStore = new CosmosRecordStore(_options);
+    _recordStore = new CosmosRecordStore(_options);
   }
 
   [Fact]

--- a/EventSourcing.Cosmos.Tests/RecordAttributeTests.cs
+++ b/EventSourcing.Cosmos.Tests/RecordAttributeTests.cs
@@ -17,8 +17,8 @@ public partial class CosmosEventSourcingTests
     var e = new EmptyAggregate().Apply(new AttributeEvent("something"));
     var recordType = e.GetType().GetCustomAttribute<RecordTypeAttribute>()!.Type;
 
-    await RecordStore.AddEventsAsync(new [] { e });
-    var result = await RecordStore
+    await GetRecordStore().AddEventsAsync(new [] { e });
+    var result = await GetRecordStore()
       .GetEvents<EmptyAggregate>()
       .Where(x => x.Type == recordType && x.AggregateId == e.AggregateId)
       .AsAsyncEnumerable()
@@ -33,9 +33,9 @@ public partial class CosmosEventSourcingTests
     var e = new EmptyAggregate().Apply(new AttributeEvent("something"));
     var recordType = e.GetType().GetCustomAttribute<RecordTypeAttribute>()!.Type;
 
-    await RecordStore.AddEventsAsync(new [] { e });
+    await GetRecordStore().AddEventsAsync(new [] { e });
 
-    var result = await RecordStore
+    var result = await GetRecordStore()
       .GetEvents<EmptyAggregate>()
       .Where(x => x.Type == recordType && x.AggregateId == e.AggregateId)
       .AsAsyncEnumerable()

--- a/EventSourcing.Cosmos/EventSourcing.Cosmos.csproj
+++ b/EventSourcing.Cosmos/EventSourcing.Cosmos.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <OutputType>Library</OutputType>
         <PackageId>Finaps.EventSourcing.Cosmos</PackageId>
-        <Version>0.4.2</Version>
+        <Version>0.4.3</Version>
         <Authors>Niels Disveld, Bram Kraaijeveld</Authors>
         <Company>Finaps B.V.</Company>
         <RepositoryUrl>https://github.com/Finaps/EventSourcing</RepositoryUrl>

--- a/EventSourcing.EF.Tests.Postgres/PostgresEventSourcingTests.cs
+++ b/EventSourcing.EF.Tests.Postgres/PostgresEventSourcingTests.cs
@@ -5,6 +5,6 @@ namespace Finaps.EventSourcing.EF.Tests.Postgres;
 
 public class PostgresEventSourcingTests : EntityFrameworkEventSourcingTests
 {
-  protected override IRecordStore RecordStore => new EntityFrameworkRecordStore(RecordContext);
-  public override RecordContext RecordContext => new TestContextFactory().CreateDbContext(Array.Empty<string>());
+  protected override IRecordStore GetRecordStore() => new EntityFrameworkRecordStore(GetRecordContext());
+  public override RecordContext GetRecordContext() => new TestContextFactory().CreateDbContext(Array.Empty<string>());
 }

--- a/EventSourcing.EF.Tests.SqlServer/SqlServerEventSourcingTests.cs
+++ b/EventSourcing.EF.Tests.SqlServer/SqlServerEventSourcingTests.cs
@@ -5,6 +5,8 @@ namespace Finaps.EventSourcing.EF.Tests.SqlServer;
 
 public class SqlServerEventSourcingTests : EntityFrameworkEventSourcingTests
 {
-  public override RecordContext RecordContext => new SqlServerTestContextFactory().CreateDbContext(Array.Empty<string>());
-  protected override IRecordStore RecordStore => new EntityFrameworkRecordStore(RecordContext);
+  public override RecordContext GetRecordContext() =>
+    new SqlServerTestContextFactory().CreateDbContext(Array.Empty<string>());
+
+  protected override IRecordStore GetRecordStore() => new EntityFrameworkRecordStore(GetRecordContext());
 }

--- a/EventSourcing.EF.Tests/AggregateReferenceTests.cs
+++ b/EventSourcing.EF.Tests/AggregateReferenceTests.cs
@@ -14,7 +14,7 @@ public abstract partial class EntityFrameworkEventSourcingTests
   {
     var referenced = new ReferenceAggregate();
     referenced.Apply(new ReferenceEvent(referenced.Id));
-    await AggregateService.PersistAsync(referenced);
+    await GetAggregateService().PersistAsync(referenced);
   }
   
   [Fact]
@@ -22,11 +22,11 @@ public abstract partial class EntityFrameworkEventSourcingTests
   {
     var referenced = new ReferenceAggregate();
     referenced.Apply(new ReferenceEvent(referenced.Id));
-    await AggregateService.PersistAsync(referenced);
+    await GetAggregateService().PersistAsync(referenced);
 
     var aggregate = new ReferenceAggregate();
     aggregate.Apply(new ReferenceEvent(referenced.Id));
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
   }
   
   [Fact]
@@ -34,17 +34,17 @@ public abstract partial class EntityFrameworkEventSourcingTests
   {
     var referenced = new ReferenceAggregate();
     referenced.Apply(new ReferenceEvent(referenced.Id));
-    await AggregateService.PersistAsync(referenced);
+    await GetAggregateService().PersistAsync(referenced);
 
     var aggregate = new ReferenceAggregate();
     aggregate.Apply(new ReferenceEvent(referenced.Id));
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
     
     var newReferenced = new ReferenceAggregate();
     newReferenced.Apply(new ReferenceEvent(newReferenced.Id));
-    await AggregateService.PersistAsync(newReferenced);
+    await GetAggregateService().PersistAsync(newReferenced);
 
-    await AggregateService.RehydrateAndPersistAsync<ReferenceAggregate>(aggregate.Id, x =>
+    await GetAggregateService().RehydrateAndPersistAsync<ReferenceAggregate>(aggregate.Id, x =>
       x.Apply(new ReferenceEvent(newReferenced.Id)));
   }
   
@@ -53,11 +53,11 @@ public abstract partial class EntityFrameworkEventSourcingTests
   {
     var referenced = new EmptyAggregate();
     referenced.Apply(new EmptyEvent());
-    await AggregateService.PersistAsync(referenced);
+    await GetAggregateService().PersistAsync(referenced);
 
     var aggregate = new ReferenceAggregate();
     aggregate.Apply(new ReferenceEvent(aggregate.Id, referenced.Id));
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
   }
   
   [Fact]
@@ -65,11 +65,11 @@ public abstract partial class EntityFrameworkEventSourcingTests
   {
     var referenced = new SimpleAggregate();
     referenced.Apply(new SimpleEvent());
-    await AggregateService.PersistAsync(referenced);
+    await GetAggregateService().PersistAsync(referenced);
 
     var aggregate = new ReferenceAggregate();
     aggregate.Apply(new ReferenceEvent(aggregate.Id, referenced.Id));
-    await Assert.ThrowsAsync<RecordStoreException>(async () => await AggregateService.PersistAsync(aggregate));
+    await Assert.ThrowsAsync<RecordStoreException>(async () => await GetAggregateService().PersistAsync(aggregate));
   }
   
   [Fact]
@@ -77,6 +77,6 @@ public abstract partial class EntityFrameworkEventSourcingTests
   {
     var aggregate = new ReferenceAggregate();
     aggregate.Apply(new ReferenceEvent(Guid.NewGuid(), null));
-    await Assert.ThrowsAsync<RecordStoreException>(async () => await AggregateService.PersistAsync(aggregate));
+    await Assert.ThrowsAsync<RecordStoreException>(async () => await GetAggregateService().PersistAsync(aggregate));
   }
 }

--- a/EventSourcing.EF.Tests/DbContextTransactionTests.cs
+++ b/EventSourcing.EF.Tests/DbContextTransactionTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading.Tasks;
+using Finaps.EventSourcing.Core;
+using Finaps.EventSourcing.Core.Tests.Mocks;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Finaps.EventSourcing.EF.Tests;
+
+public abstract partial class EntityFrameworkEventSourcingTests
+{
+  [Fact]
+  public async Task DbContextTransactionTests_Can_Use_Custom_Transaction()
+  {
+    var store = (EntityFrameworkRecordStore) GetRecordStore();
+    var service = new AggregateService(store);
+    
+    await using var transaction = await store.Context.Database.BeginTransactionAsync();
+
+    var bankaccount = new BankAccount();
+    bankaccount.Apply(new BankAccountCreatedEvent("E. Vent", "Some IBAN"));
+
+    while (bankaccount.Balance < 100)
+      bankaccount.Apply(new BankAccountFundsDepositedEvent(10));
+
+    await service.PersistAsync(bankaccount);
+
+    var projection = bankaccount.Project<BankAccountProjection>()! with { AggregateId = Guid.NewGuid() };
+
+    await store.UpsertProjectionAsync(projection);
+    
+    // After persisting, check events, snapshots and projections have been inserted
+    Assert.True(await store.GetEvents<BankAccount>().AnyAsync(x => x.AggregateId == bankaccount.Id));
+    Assert.True(await store.GetSnapshots<BankAccount>().AnyAsync(x => x.AggregateId == bankaccount.Id));
+    Assert.True(await store.GetProjections<BankAccountProjection>().AnyAsync(x => x.AggregateId == bankaccount.Id));
+    Assert.True(await store.GetProjections<BankAccountProjection>().AnyAsync(x => x.AggregateId == projection.AggregateId));
+
+    await transaction.RollbackAsync();
+
+    // After rollback, check that all actions have been undone
+    Assert.False(await store.GetEvents<BankAccount>().AnyAsync(x => x.AggregateId == bankaccount.Id));
+    Assert.False(await store.GetSnapshots<BankAccount>().AnyAsync(x => x.AggregateId == bankaccount.Id));
+    Assert.False(await store.GetProjections<BankAccountProjection>().AnyAsync(x => x.AggregateId == bankaccount.Id));
+    Assert.False(await store.GetProjections<BankAccountProjection>().AnyAsync(x => x.AggregateId == projection.AggregateId));
+  }
+  
+  [Fact]
+  public async Task DbContextTransactionTests_Transaction_Is_Rolled_Back_On_Conflict()
+  {
+    var store = (EntityFrameworkRecordStore) GetRecordStore();
+    var service = new AggregateService(store);
+    
+    var bankaccount = new BankAccount();
+    var recordStoreExceptionOccurred = false;
+
+    try
+    {
+      await using var transaction = await store.Context.Database.BeginTransactionAsync();
+
+      var @event = bankaccount.Apply(new BankAccountCreatedEvent("E. Vent", "Some IBAN"));
+
+      while (bankaccount.Balance < 100)
+        bankaccount.Apply(new BankAccountFundsDepositedEvent(10));
+
+      await service.PersistAsync(bankaccount);
+
+      // After persisting, check events, snapshots and projections have been inserted
+      Assert.True(await store.GetEvents<BankAccount>().AnyAsync(x => x.AggregateId == bankaccount.Id));
+      Assert.True(await store.GetSnapshots<BankAccount>().AnyAsync(x => x.AggregateId == bankaccount.Id));
+      Assert.True(await store.GetProjections<BankAccountProjection>().AnyAsync(x => x.AggregateId == bankaccount.Id));
+
+      await store.AddEventsAsync(new[] { @event });
+      await transaction.CommitAsync();
+    }
+    catch (RecordStoreException)
+    {
+      recordStoreExceptionOccurred = true;
+    }
+    finally
+    {
+      Assert.True(recordStoreExceptionOccurred);
+      
+      // After conflict, check that all actions have been undone
+      Assert.False(await store.GetEvents<BankAccount>().AnyAsync(x => x.AggregateId == bankaccount.Id));
+      Assert.False(await store.GetSnapshots<BankAccount>().AnyAsync(x => x.AggregateId == bankaccount.Id));
+      Assert.False(await store.GetProjections<BankAccountProjection>().AnyAsync(x => x.AggregateId == bankaccount.Id));
+    }
+  }
+}

--- a/EventSourcing.EF.Tests/EntityFrameworkEventSourcingTests.cs
+++ b/EventSourcing.EF.Tests/EntityFrameworkEventSourcingTests.cs
@@ -4,5 +4,5 @@ namespace Finaps.EventSourcing.EF.Tests;
 
 public abstract partial class EntityFrameworkEventSourcingTests : EventSourcingTests
 {
-  public abstract RecordContext RecordContext { get; }
+  public abstract RecordContext GetRecordContext();
 }

--- a/EventSourcing.EF.Tests/EventIntegrityTests.cs
+++ b/EventSourcing.EF.Tests/EventIntegrityTests.cs
@@ -13,7 +13,7 @@ public abstract partial class EntityFrameworkEventSourcingTests
   [Fact]
   public async Task EventIntegrityTests_Can_Insert_Event()
   {
-    var context = RecordContext;
+    var context = GetRecordContext();
     
     var entry = context.Add(new SimpleEvent
     {
@@ -36,9 +36,9 @@ public abstract partial class EntityFrameworkEventSourcingTests
       .Select(_ => aggregate.Apply(new SimpleEvent()))
       .ToList();
     
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
     
-    var context = RecordContext;
+    var context = GetRecordContext();
     
     Assert.True(await context.Set<SimpleEvent>().AnyAsync(x => x.AggregateId == aggregate.Id && x.Index == 9));
 
@@ -51,7 +51,7 @@ public abstract partial class EntityFrameworkEventSourcingTests
   [Fact]
   public async Task EventIntegrityTests_Cannot_Insert_Event_With_Null_AggregateType()
   {
-    var context = RecordContext;
+    var context = GetRecordContext();
     
     context.Add(new SimpleEvent
     {
@@ -65,7 +65,7 @@ public abstract partial class EntityFrameworkEventSourcingTests
   [Fact]
   public async Task EventIntegrityTests_Cannot_Insert_Nonconsecutive_Event()
   {
-    var context = RecordContext;
+    var context = GetRecordContext();
     
     context.Add(new SimpleEvent
     {
@@ -87,9 +87,9 @@ public abstract partial class EntityFrameworkEventSourcingTests
       .Select(_ => aggregate.Apply(new SimpleEvent()))
       .ToList();
     
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var context = RecordContext;
+    var context = GetRecordContext();
 
     context.Remove(events[5]);
     await Assert.ThrowsAsync<DbUpdateException>(async () => await context.SaveChangesAsync());
@@ -98,7 +98,7 @@ public abstract partial class EntityFrameworkEventSourcingTests
   [Fact]
   public async Task EventIntegrityTests_Cannot_Create_Event_With_Negative_Index()
   {
-    var context = RecordContext;
+    var context = GetRecordContext();
     
     context.Add(new SimpleEvent
     {
@@ -120,9 +120,9 @@ public abstract partial class EntityFrameworkEventSourcingTests
       .Select(_ => aggregate.Apply(new SnapshotEvent()))
       .ToList();
     
-    await AggregateService.PersistAsync(aggregate);
+    await GetAggregateService().PersistAsync(aggregate);
 
-    var context = RecordContext;
+    var context = GetRecordContext();
 
     Assert.True(await context.Set<SnapshotSnapshot>().AnyAsync(x => x.AggregateId == aggregate.Id));
 
@@ -136,6 +136,6 @@ public abstract partial class EntityFrameworkEventSourcingTests
   public async Task EventIntegrityTests_Cannot_Add_Snapshot_Without_Corresponding_Event()
   {
     var snapshot = new SnapshotSnapshot { AggregateId = Guid.NewGuid(), Index = 0 };
-    await Assert.ThrowsAsync<RecordStoreException>(async () => await RecordStore.AddSnapshotAsync(snapshot));
+    await Assert.ThrowsAsync<RecordStoreException>(async () => await GetRecordStore().AddSnapshotAsync(snapshot));
   }
 }

--- a/EventSourcing.EF/EntityFrameworkRecordStore.cs
+++ b/EventSourcing.EF/EntityFrameworkRecordStore.cs
@@ -9,7 +9,7 @@ public class EntityFrameworkRecordStore : IRecordStore
 {
   internal static List<Type> ProjectionTypes { get; } = new();
 
-  internal RecordContext Context { get; set; }
+  public RecordContext Context { get; }
 
   /// <summary>
   /// Initialize Entity Framework Record Store

--- a/EventSourcing.EF/EntityFrameworkRecordStore.cs
+++ b/EventSourcing.EF/EntityFrameworkRecordStore.cs
@@ -9,6 +9,9 @@ public class EntityFrameworkRecordStore : IRecordStore
 {
   internal static List<Type> ProjectionTypes { get; } = new();
 
+  /// <summary>
+  /// <see cref="RecordContext"/>
+  /// </summary>
   public RecordContext Context { get; }
 
   /// <summary>

--- a/EventSourcing.EF/EventSourcing.EF.csproj
+++ b/EventSourcing.EF/EventSourcing.EF.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <OutputType>Library</OutputType>
         <PackageId>Finaps.EventSourcing.EF</PackageId>
-        <Version>0.4.2</Version>
+        <Version>0.4.3</Version>
         <Authors>Niels Disveld, Bram Kraaijeveld</Authors>
         <Company>Finaps B.V.</Company>
         <RepositoryUrl>https://github.com/Finaps/EventSourcing</RepositoryUrl>


### PR DESCRIPTION
- Allow custom ```DbContextTransaction``` to interop with ```EntityFrameworkRecordTransaction```
- Change ```RecordStore```/```RecordTransaction``` auto-properties to methods to avoid confusion in tests
- Bump to version 0.4.3